### PR TITLE
Fix `go get` command for library in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Install from GitHub using `go get`_:
 
 .. code-block:: bash
 
-    $ go get https://github.com/SparkPost/gosparkpost
+    $ go get github.com/SparkPost/gosparkpost
 
 .. _go get: https://golang.org/cmd/go/#hdr-Download_and_install_packages_and_dependencies
 


### PR DESCRIPTION
Using the current version of the command in the doc via copy/paste yields:

```
$ go get https://github.com/SparkPost/gosparkpost
package https:/github.com/SparkPost/gosparkpost: "https://" not allowed in import path
```

This PR corrects the `go get` command to not include the protocol.