### PR TITLE
allow using any serializable type for metadata / substitution data

### DIFF
--- a/common.go
+++ b/common.go
@@ -8,15 +8,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"reflect"
 	"regexp"
 	"strings"
 
 	certifi "github.com/certifi/gocertifi"
 )
-
-// TODO: define paths statically in each endpoint's file, move version to Config
-// TODO: rename e.g. Transmissions.Create to Client.SendTransmission
 
 // Config includes all information necessary to make an API request.
 type Config struct {

--- a/common.go
+++ b/common.go
@@ -249,30 +249,6 @@ func (r *Response) ParseResponse() error {
 	return nil
 }
 
-// AssertObject asserts that the provided variable is a map[string]something.
-// The string parameter is used to customize the generated error message.
-func AssertObject(obj interface{}, label string) error {
-	// List of handled types from here:
-	// http://golang.org/pkg/encoding/json/#Unmarshal
-	switch objVal := obj.(type) {
-	case map[string]interface{}:
-		// auto-parsed nested json object
-	case map[string]bool:
-		// user-provided json literal (convenience)
-	case map[string]float64:
-		// user-provided json literal (convenience)
-	case map[string]string:
-		// user-provided json literal (convenience)
-	case map[string][]interface{}:
-		// user-provided json literal (convenience)
-	case map[string]map[string]interface{}:
-		// user-provided json literal (convenience)
-	default:
-		return fmt.Errorf("expected key/val pairs for %s, got [%s]", label, reflect.TypeOf(objVal))
-	}
-	return nil
-}
-
 // AssertJson returns an error if the provided HTTP response isn't JSON.
 func (r *Response) AssertJson() error {
 	if r.HTTP == nil {

--- a/recipient_lists.go
+++ b/recipient_lists.go
@@ -133,23 +133,6 @@ func (r Recipient) Validate() error {
 	if err != nil {
 		return err
 	}
-
-	// Metadata must be an object, not an array or bool etc.
-	if r.Metadata != nil {
-		err := AssertObject(r.Metadata, "metadata")
-		if err != nil {
-			return err
-		}
-	}
-
-	// SubstitutionData must be an object, not an array or bool etc.
-	if r.SubstitutionData != nil {
-		err := AssertObject(r.SubstitutionData, "substitution_data")
-		if err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/transmissions.go
+++ b/transmissions.go
@@ -181,22 +181,6 @@ func (t *Transmission) Validate() error {
 		return err
 	}
 
-	// Metadata must be an object, not an array or bool etc.
-	if t.Metadata != nil {
-		err := AssertObject(t.Metadata, "metadata")
-		if err != nil {
-			return err
-		}
-	}
-
-	// SubstitutionData must be an object, not an array or bool etc.
-	if t.SubstitutionData != nil {
-		err := AssertObject(t.SubstitutionData, "substitution_data")
-		if err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
remove type checks - this allows setting metadata or substitution data to any type that can be serialized to json