### PR TITLE
Remove ErrWebhookValidation (see #52)

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -19,8 +19,7 @@ type Event interface {
 type Events []Event
 
 var (
-	ErrWebhookValidation = errors.New("webhook validation request")
-	ErrNotImplemented    = errors.New("not implemented")
+	ErrNotImplemented = errors.New("not implemented")
 )
 
 // ValidEventType returns true if the event name parameter is valid.
@@ -117,9 +116,6 @@ func (events *Events) UnmarshalJSON(data []byte) error {
 	// Parse raw events from Event Webhook ("msys"-wrapped array of events).
 	rawEvents, err := parseRawJSONEventsFromWebhook(data)
 	if err != nil {
-		if err == ErrWebhookValidation {
-			return err
-		}
 		// Parse raw events from Event Samples ("results" object with array of events).
 		rawEvents, err = parseRawJSONEventsFromSamples(data)
 		if err != nil {
@@ -143,11 +139,6 @@ func parseRawJSONEventsFromWebhook(data []byte) ([]json.RawMessage, error) {
 	}
 	if err := json.Unmarshal(data, &msysEventWrappers); err != nil {
 		return nil, err
-	}
-
-	// Empty "msys" wrapper is used for webhook validation.
-	if len(msysEventWrappers) == 1 && len(msysEventWrappers[0].MsysEventWrapper) == 0 {
-		return nil, ErrWebhookValidation
 	}
 
 	for _, wrapper := range msysEventWrappers {

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -44,7 +44,10 @@ func TestSampleWebhookValidationRequest(t *testing.T) {
 
 	var events Events
 	err = json.Unmarshal(payload, &events)
-	if err != ErrWebhookValidation {
-		t.Fatalf("expected ErrWebhookValidation error, got %v", err)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected zero events, got %d: %v", len(events), events)
 	}
 }


### PR DESCRIPTION
Sparkpost's special “validation” call on webhook receivers should not be treated as an error. It’s cleaner to treat this as a normal webhook call with zero number of events. This way, the users of the package don’t have to treat this single error separately.

This commit does just that: it removes `ErrWebhookValidation` and returns an empty list of events and a nil error for validation requests. Now, if parsing webhook data return an error it means that there really is an error. No need for special `if`s to ignore `ErrWebhookValidation`.