### PR TITLE
remove stray prints in verbose mode

### DIFF
--- a/cmd/sparks/sparks.go
+++ b/cmd/sparks/sparks.go
@@ -53,6 +53,7 @@ var inline = flag.Bool("inline-css", false, "automatically inline css")
 var dryrun = flag.Bool("dry-run", false, "dump json that would be sent to server")
 var url = flag.String("url", "", "base url for api requests (optional)")
 var help = flag.Bool("help", false, "display a help message")
+var httpDump = flag.Bool("httpdump", false, "dump out http request and response")
 
 func main() {
 	flag.Parse()
@@ -85,6 +86,9 @@ func main() {
 			log.Fatal("FATAL: base url must be https!\n")
 		}
 		cfg.BaseUrl = *url
+	}
+	if *httpDump {
+		cfg.Verbose = true
 	}
 
 	var sparky sp.Client
@@ -264,5 +268,20 @@ func main() {
 		log.Fatal(err)
 	}
 
-	log.Printf("HTTP [%s] TX %s\n", req.HTTP.Status, id)
+	if *httpDump {
+		if reqDump, ok := req.Verbose["http_requestdump"]; ok {
+			os.Stdout.Write([]byte(reqDump))
+		} else {
+			os.Stdout.Write([]byte("*** No request dump available! ***\n\n"))
+		}
+
+		if resDump, ok := req.Verbose["http_responsedump"]; ok {
+			os.Stdout.Write([]byte(resDump))
+			os.Stdout.Write([]byte("\n"))
+		} else {
+			os.Stdout.Write([]byte("*** No response dump available! ***\n"))
+		}
+	} else {
+		log.Printf("HTTP [%s] TX %s\n", req.HTTP.Status, id)
+	}
 }

--- a/common.go
+++ b/common.go
@@ -165,15 +165,17 @@ func (c *Client) DoRequest(method, urlStr string, data []byte) (*Response, error
 	}
 
 	ares := &Response{}
-	if c.Config.Verbose && ares.Verbose == nil {
-		ares.Verbose = map[string]string{}
+	if c.Config.Verbose {
+		if ares.Verbose == nil {
+			ares.Verbose = map[string]string{}
+		}
+		ares.Verbose["http_method"] = method
+		ares.Verbose["http_uri"] = urlStr
 	}
 	if data != nil {
 		req.Header.Set("Content-Type", "application/json")
 
 		if c.Config.Verbose {
-			ares.Verbose["http_method"] = method
-			ares.Verbose["http_uri"] = urlStr
 			ares.Verbose["http_postdata"] = string(data)
 		}
 	}


### PR DESCRIPTION
Client library shouldn't be printing stuff all willy nilly. Return it as part of our `Response` instead for consumers to do whatever they like with. Includes example usage with the `sparks` tool.