### PR TITLE
Allow TmplOptions to be set to false

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -59,9 +59,9 @@ type From struct {
 // Options specifies settings to apply to this Template.
 // These settings may be overridden in the Transmission API call.
 type TmplOptions struct {
-	OpenTracking  bool `json:"open_tracking,omitempty"`
-	ClickTracking bool `json:"click_tracking,omitempty"`
-	Transactional bool `json:"transactional,omitempty"`
+	OpenTracking  bool `json:"open_tracking"`
+	ClickTracking bool `json:"click_tracking"`
+	Transactional bool `json:"transactional"`
 }
 
 // Preview options contains the required subsitution_data object to


### PR DESCRIPTION
Currently if they're set to false they'll be omitted due to the 'omitempty' declaration.
