### PR TITLE
sparks: add an --rfc822 option

### DIFF
--- a/common.go
+++ b/common.go
@@ -61,8 +61,8 @@ type Response struct {
 	HTTP    *http.Response
 	Body    []byte
 	Verbose map[string]string
-	Results map[string]interface{} `json:"results,omitempty"`
-	Errors  []Error                `json:"errors,omitempty"`
+	Results interface{} `json:"results,omitempty"`
+	Errors  []Error     `json:"errors,omitempty"`
 }
 
 // Error mirrors the error format returned by SparkPost APIs.

--- a/common.go
+++ b/common.go
@@ -25,7 +25,7 @@ type Config struct {
 	Verbose    bool
 }
 
-// Client contains connection and authentication information.
+// Client contains connection, configuration, and authentication information.
 // Specifying your own http.Client gives you lots of control over how connections are made.
 type Client struct {
 	Config  *Config
@@ -120,7 +120,7 @@ func (api *Client) Init(cfg *Config) error {
 }
 
 // SetHeader adds additional HTTP headers for every API request made from client.
-// Usefull to set subaccount X-MSYS-SUBACCOUNT header and etc.
+// Useful to set subaccount X-MSYS-SUBACCOUNT header and etc.
 func (c *Client) SetHeader(header string, value string) {
 	c.headers[header] = value
 }

--- a/recipient_lists.go
+++ b/recipient_lists.go
@@ -175,9 +175,13 @@ func (c *Client) RecipientListCreate(rl *RecipientList) (id string, res *Respons
 
 	if res.HTTP.StatusCode == 200 {
 		var ok bool
-		id, ok = res.Results["id"].(string)
+		var results map[string]interface{}
+		if results, ok = res.Results.(map[string]interface{}); !ok {
+			return id, res, fmt.Errorf("Unexpected response to Recipient List creation (results)")
+		}
+		id, ok = results["id"].(string)
 		if !ok {
-			err = fmt.Errorf("Unexpected response to Recipient List creation")
+			return id, res, fmt.Errorf("Unexpected response to Recipient List creation (id)")
 		}
 
 	} else if len(res.Errors) > 0 {

--- a/subaccounts.go
+++ b/subaccounts.go
@@ -81,12 +81,16 @@ func (c *Client) SubaccountCreate(s *Subaccount) (res *Response, err error) {
 
 	if res.HTTP.StatusCode == 200 {
 		var ok bool
-		f, ok := res.Results["subaccount_id"].(float64)
+		var results map[string]interface{}
+		if results, ok = res.Results.(map[string]interface{}); !ok {
+			return res, fmt.Errorf("Unexpected response to Subaccount creation (results)")
+		}
+		f, ok := results["subaccount_id"].(float64)
 		if !ok {
 			err = fmt.Errorf("Unexpected response to Subaccount creation")
 		}
 		s.ID = int(f)
-		s.ShortKey, ok = res.Results["short_key"].(string)
+		s.ShortKey, ok = results["short_key"].(string)
 		if !ok {
 			err = fmt.Errorf("Unexpected response to Subaccount creation")
 		}

--- a/suppression_list.go
+++ b/suppression_list.go
@@ -143,6 +143,11 @@ func suppressionGet(c *Client, finalUrl string) (*SuppressionListWrapper, *Respo
 		return nil, res, err
 	}
 
+	err = res.ParseResponse()
+	if err != nil {
+		return nil, res, err
+	}
+
 	// Get the Content
 	bodyBytes, err := res.ReadBody()
 	if err != nil {

--- a/suppression_list_test.go
+++ b/suppression_list_test.go
@@ -1,0 +1,112 @@
+package gosparkpost
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+var combinedSuppressionList string = `{
+  "results": [
+    {
+      "recipient": "rcpt_1@example.com",
+      "transactional": true,
+      "non_transactional": true,
+      "source": "Manually Added",
+      "description": "User requested to not receive any non-transactional emails.",
+      "created": "2016-01-01T12:00:00+00:00",
+      "updated": "2016-01-01T12:00:00+00:00"
+    }
+  ]
+}`
+
+var separateSuppressionList string = `{
+  "results": [
+    {
+      "recipient": "rcpt_1@example.com",
+      "non_transactional": true,
+      "source": "Manually Added",
+      "type": "non_transactional",
+      "description": "User requested to not receive any non-transactional emails.",
+      "created": "2016-01-01T12:00:00+00:00",
+      "updated": "2016-01-01T12:00:00+00:00"
+    },
+    {
+      "recipient": "rcpt_1@example.com",
+      "transactional": true,
+      "source": "Bounce Rule",
+      "type": "transactional",
+      "description": "550: 550-5.1.1 Invalid Recipient",
+      "created": "2015-10-15T12:00:00+00:00",
+      "updated": "2015-10-15T12:00:00+00:00"
+    }
+  ],
+  "links": [],
+  "total_count": 2
+}`
+
+// Test parsing of combined suppression list results
+func TestSuppression_Get_combinedList(t *testing.T) {
+	testSetup(t)
+	defer testTeardown()
+
+	// set up the response handler
+	path := fmt.Sprintf(suppressionListsPathFormat, testClient.Config.ApiVersion)
+	testMux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json; charset=utf8")
+		w.Write([]byte(combinedSuppressionList))
+	})
+
+	// hit our local handler
+	s, res, err := testClient.SuppressionList()
+	if err != nil {
+		t.Errorf("SuppressionList GET returned error: %v", err)
+		for _, e := range res.Verbose {
+			t.Error(e)
+		}
+		return
+	}
+
+	// basic content test
+	if s.Results == nil {
+		t.Error("SuppressionList GET returned nil Results")
+	} else if len(s.Results) != 1 {
+		t.Errorf("SuppressionList GET returned %d results, expected %d", len(s.Results), 1)
+	} else if s.Results[0].Recipient != "rcpt_1@example.com" {
+		t.Errorf("SuppressionList GET Unmarshal error; saw [%v] expected [rcpt_1@example.com]", s.Results[0].Recipient)
+	}
+}
+
+// Test parsing of separate suppression list results
+func TestSuppression_Get_separateList(t *testing.T) {
+	testSetup(t)
+	defer testTeardown()
+
+	// set up the response handler
+	path := fmt.Sprintf(suppressionListsPathFormat, testClient.Config.ApiVersion)
+	testMux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json; charset=utf8")
+		w.Write([]byte(separateSuppressionList))
+	})
+
+	// hit our local handler
+	s, res, err := testClient.SuppressionList()
+	if err != nil {
+		t.Errorf("SuppressionList GET returned error: %v", err)
+		for _, e := range res.Verbose {
+			t.Error(e)
+		}
+		return
+	}
+
+	// basic content test
+	if s.Results == nil {
+		t.Error("SuppressionList GET returned nil Results")
+	} else if len(s.Results) != 2 {
+		t.Errorf("SuppressionList GET returned %d results, expected %d", len(s.Results), 2)
+	} else if s.Results[0].Recipient != "rcpt_1@example.com" {
+		t.Errorf("SuppressionList GET Unmarshal error; saw [%v] expected [rcpt_1@example.com]", s.Results[0].Recipient)
+	}
+}

--- a/suppression_list_test.go
+++ b/suppression_list_test.go
@@ -6,6 +6,47 @@ import (
 	"testing"
 )
 
+var suppressionNotFound string = `{
+	"errors": [
+		{
+			"message": "Recipient could not be found"
+		}
+	]
+}`
+
+// Test parsing of "not found" case
+func TestSuppression_Get_notFound(t *testing.T) {
+	testSetup(t)
+	defer testTeardown()
+
+	// set up the response handler
+	path := fmt.Sprintf(suppressionListsPathFormat, testClient.Config.ApiVersion)
+	testMux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json; charset=utf8")
+		w.WriteHeader(http.StatusNotFound) // 404
+		w.Write([]byte(suppressionNotFound))
+	})
+
+	// hit our local handler
+	s, res, err := testClient.SuppressionList()
+	if err != nil {
+		testFailVerbose(t, res, "SuppressionList GET returned error: %v", err)
+	}
+
+	// basic content test
+	if s.Results != nil {
+		testFailVerbose(t, res, "SuppressionList GET returned non-nil Results (error expected)")
+	} else if len(s.Results) != 0 {
+		testFailVerbose(t, res, "SuppressionList GET returned %d results, expected %d", len(s.Results), 0)
+	} else if len(res.Errors) != 1 {
+		testFailVerbose(t, res, "SuppressionList GET returned %d errors, expected %d", len(res.Errors), 1)
+	} else if res.Errors[0].Message != "Recipient could not be found" {
+		testFailVerbose(t, res, "SuppressionList GET Unmarshal error; saw [%v] expected [%v]",
+			res.Errors[0].Message, "Recipient could not be found")
+	}
+}
+
 var combinedSuppressionList string = `{
   "results": [
     {
@@ -18,31 +59,6 @@ var combinedSuppressionList string = `{
       "updated": "2016-01-01T12:00:00+00:00"
     }
   ]
-}`
-
-var separateSuppressionList string = `{
-  "results": [
-    {
-      "recipient": "rcpt_1@example.com",
-      "non_transactional": true,
-      "source": "Manually Added",
-      "type": "non_transactional",
-      "description": "User requested to not receive any non-transactional emails.",
-      "created": "2016-01-01T12:00:00+00:00",
-      "updated": "2016-01-01T12:00:00+00:00"
-    },
-    {
-      "recipient": "rcpt_1@example.com",
-      "transactional": true,
-      "source": "Bounce Rule",
-      "type": "transactional",
-      "description": "550: 550-5.1.1 Invalid Recipient",
-      "created": "2015-10-15T12:00:00+00:00",
-      "updated": "2015-10-15T12:00:00+00:00"
-    }
-  ],
-  "links": [],
-  "total_count": 2
 }`
 
 // Test parsing of combined suppression list results
@@ -77,6 +93,31 @@ func TestSuppression_Get_combinedList(t *testing.T) {
 		t.Errorf("SuppressionList GET Unmarshal error; saw [%v] expected [rcpt_1@example.com]", s.Results[0].Recipient)
 	}
 }
+
+var separateSuppressionList string = `{
+  "results": [
+    {
+      "recipient": "rcpt_1@example.com",
+      "non_transactional": true,
+      "source": "Manually Added",
+      "type": "non_transactional",
+      "description": "User requested to not receive any non-transactional emails.",
+      "created": "2016-01-01T12:00:00+00:00",
+      "updated": "2016-01-01T12:00:00+00:00"
+    },
+    {
+      "recipient": "rcpt_1@example.com",
+      "transactional": true,
+      "source": "Bounce Rule",
+      "type": "transactional",
+      "description": "550: 550-5.1.1 Invalid Recipient",
+      "created": "2015-10-15T12:00:00+00:00",
+      "updated": "2015-10-15T12:00:00+00:00"
+    }
+  ],
+  "links": [],
+  "total_count": 2
+}`
 
 // Test parsing of separate suppression list results
 func TestSuppression_Get_separateList(t *testing.T) {

--- a/templates.go
+++ b/templates.go
@@ -219,7 +219,11 @@ func (c *Client) TemplateCreate(t *Template) (id string, res *Response, err erro
 
 	if res.HTTP.StatusCode == 200 {
 		var ok bool
-		id, ok = res.Results["id"].(string)
+		var results map[string]interface{}
+		if results, ok = res.Results.(map[string]interface{}); !ok {
+			return id, res, fmt.Errorf("Unexpected response to Template creation (results)")
+		}
+		id, ok = results["id"].(string)
 		if !ok {
 			err = fmt.Errorf("Unexpected response to Template creation")
 		}

--- a/test_server.go
+++ b/test_server.go
@@ -1,0 +1,44 @@
+package gosparkpost
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+var (
+	testMux    *http.ServeMux
+	testClient *Client
+	testServer *httptest.Server
+)
+
+func testSetup(t *testing.T) {
+	// spin up a test server
+	testMux = http.NewServeMux()
+	testServer = httptest.NewTLSServer(testMux)
+	// our client configured to hit the https test server with self-signed cert
+	tx := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	testClient = &Client{Client: &http.Client{Transport: tx}}
+	testClient.Config = &Config{Verbose: true}
+	testUrl, err := url.Parse(testServer.URL)
+	if err != nil {
+		t.Fatalf("Test server url parsing failed: %v", err)
+	}
+	testClient.Config.BaseUrl = testUrl.String()
+	err = testClient.Init(testClient.Config)
+	if err != nil {
+		t.Fatalf("Test client init failed: %v", err)
+	}
+}
+
+func testTeardown() {
+	testServer.Close()
+}
+
+func testMethod(t *testing.T, r *http.Request, want string) {
+	if got := r.Method; got != want {
+		t.Fatalf("Request method: %v, want %v", got, want)
+	}
+}

--- a/test_server.go
+++ b/test_server.go
@@ -42,3 +42,10 @@ func testMethod(t *testing.T, r *http.Request, want string) {
 		t.Fatalf("Request method: %v, want %v", got, want)
 	}
 }
+
+func testFailVerbose(t *testing.T, res *Response, fmt string, args ...interface{}) {
+	for _, e := range res.Verbose {
+		t.Error(e)
+	}
+	t.Fatalf(fmt, args...)
+}

--- a/transmissions.go
+++ b/transmissions.go
@@ -230,7 +230,11 @@ func (c *Client) Send(t *Transmission) (id string, res *Response, err error) {
 
 	if res.HTTP.StatusCode == 200 {
 		var ok bool
-		id, ok = res.Results["id"].(string)
+		var results map[string]interface{}
+		if results, ok = res.Results.(map[string]interface{}); !ok {
+			return id, res, fmt.Errorf("Unexpected response to Transmission creation (results)")
+		}
+		id, ok = results["id"].(string)
 		if !ok {
 			err = fmt.Errorf("Unexpected response to Transmission creation")
 		}


### PR DESCRIPTION
also avoid sending empty `substitution_data`