### PR TITLE
tests for methods that hit the templates endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ go:
 before_install:
   go get github.com/mattn/goveralls
 script:
-  - $HOME/gopath/bin/goveralls -service=travis-ci -ignore 'cmd/*/*.go'
+  - $HOME/gopath/bin/goveralls -service=travis-ci -ignore 'cmd/*/*.go' -ignore 'examples/*/*.go' -ignore 'helpers/*/*.go'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ go:
 before_install:
   go get github.com/mattn/goveralls
 script:
-  - $HOME/gopath/bin/goveralls -service=travis-ci
+  - $HOME/gopath/bin/goveralls -service=travis-ci -ignore '(^|/)cmd/'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ go:
 before_install:
   go get github.com/mattn/goveralls
 script:
-  - $HOME/gopath/bin/goveralls -service=travis-ci -ignore '/cmd/'
+  - $HOME/gopath/bin/goveralls -service=travis-ci -ignore '^cmd/'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ go:
 before_install:
   go get github.com/mattn/goveralls
 script:
-  - $HOME/gopath/bin/goveralls -service=travis-ci -ignore '^cmd/'
+  - $HOME/gopath/bin/goveralls -service=travis-ci -ignore 'cmd/*/*.go'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ go:
 before_install:
   go get github.com/mattn/goveralls
 script:
-  - $HOME/gopath/bin/goveralls -service=travis-ci -ignore 'cmd/*/*.go' -ignore 'examples/*/*.go' -ignore 'helpers/*/*.go'
+  - $HOME/gopath/bin/goveralls -service=travis-ci -ignore 'cmd/*/*.go,examples/*/*.go,helpers/*/*.go'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ go:
 before_install:
   go get github.com/mattn/goveralls
 script:
-  - $HOME/gopath/bin/goveralls -service=travis-ci -ignore '(^|/)cmd/'
+  - $HOME/gopath/bin/goveralls -service=travis-ci -ignore '/cmd/'

--- a/common.go
+++ b/common.go
@@ -261,6 +261,15 @@ func (r *Response) AssertJson() error {
 	if r.HTTP == nil {
 		return errors.New("AssertJson got nil http.Response")
 	}
+	body, err := r.ReadBody()
+	if err != nil {
+		return err
+	}
+	// Don't fail on an empty response
+	if bytes.Compare(body, []byte("")) == 0 {
+		return nil
+	}
+
 	ctype := r.HTTP.Header.Get("Content-Type")
 	mediaType, _, err := mime.ParseMediaType(ctype)
 	if err != nil {

--- a/common.go
+++ b/common.go
@@ -173,15 +173,9 @@ func (c *Client) DoRequest(ctx context.Context, method, urlStr string, data []by
 	// set any headers provided in context
 	if header, ok := ctx.Value("http.Header").(http.Header); ok {
 		for key, vals := range map[string][]string(header) {
-			if len(vals) >= 1 {
-				// replace existing headers, default, or from Client.headers
-				req.Header.Set(key, vals[0])
-			}
-			if len(vals) > 2 {
-				for _, val := range vals[1:] {
-					// allow setting multiple values because why not
-					req.Header.Add(key, val)
-				}
+			req.Header.Del(key)
+			for _, val := range vals {
+				req.Header.Add(key, val)
 			}
 		}
 	}
@@ -201,7 +195,7 @@ func (c *Client) DoRequest(ctx context.Context, method, urlStr string, data []by
 	if c.Config.Verbose {
 		ares.Verbose["http_status"] = ares.HTTP.Status
 		bodyBytes, dumpErr := httputil.DumpResponse(res, true)
-		if err != nil {
+		if dumpErr != nil {
 			ares.Verbose["http_responsedump_err"] = dumpErr.Error()
 		} else {
 			ares.Verbose["http_responsedump"] = string(bodyBytes)

--- a/common.go
+++ b/common.go
@@ -29,7 +29,7 @@ type Config struct {
 // Specifying your own http.Client gives you lots of control over how connections are made.
 // Clients are safe for concurrent (read-only) reuse by multiple goroutines.
 // Headers is useful to set subaccount (X-MSYS-SUBACCOUNT header) and any other custom headers.
-// All calls to SetHeader must happen before Client is exposed to possible concurrent use.
+// All changes to Headers must happen before Client is exposed to possible concurrent use.
 type Client struct {
 	Config  *Config
 	Client  *http.Client

--- a/common.go
+++ b/common.go
@@ -65,11 +65,14 @@ type Response struct {
 	Body    []byte
 	Verbose map[string]string
 	Results interface{} `json:"results,omitempty"`
-	Errors  []Error     `json:"errors,omitempty"`
+	Errors  SPErrors    `json:"errors,omitempty"`
 }
 
-// Error mirrors the error format returned by SparkPost APIs.
-type Error struct {
+// SPErrors is the plural of SPError
+type SPErrors []SPError
+
+// SPError mirrors the error format returned by SparkPost APIs.
+type SPError struct {
 	Message     string `json:"message"`
 	Code        string `json:"code"`
 	Description string `json:"description"`
@@ -77,7 +80,8 @@ type Error struct {
 	Line        int    `json:"line,omitempty"`
 }
 
-func (e Error) Json() string {
+// Error satisfies the builtin Error interface
+func (e SPErrors) Error() string {
 	// safe to ignore errors when Marshaling a constant type
 	jsonb, _ := json.Marshal(e)
 	return string(jsonb)

--- a/common.go
+++ b/common.go
@@ -75,12 +75,10 @@ type Error struct {
 	Line        int    `json:"line,omitempty"`
 }
 
-func (e Error) Json() (string, error) {
-	jsonBytes, err := json.Marshal(e)
-	if err != nil {
-		return "", errors.Wrap(err, "marshaling json")
-	}
-	return string(jsonBytes), nil
+func (e Error) Json() string {
+	// safe to ignore errors when Marshaling a constant type
+	jsonb, _ := json.Marshal(e)
+	return string(jsonb)
 }
 
 // Init pulls together everything necessary to make an API request.

--- a/common.go
+++ b/common.go
@@ -239,6 +239,10 @@ func (r *Response) ParseResponse() error {
 	if err != nil {
 		return err
 	}
+	// Don't try to unmarshal an empty response
+	if bytes.Compare(body, []byte("")) == 0 {
+		return nil
+	}
 
 	err = json.Unmarshal(body, r)
 	if err != nil {

--- a/common_test.go
+++ b/common_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	sp "github.com/SparkPost/gosparkpost"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -52,4 +53,29 @@ func testFailVerbose(t *testing.T, res *sp.Response, fmt string, args ...interfa
 		}
 	}
 	t.Fatalf(fmt, args...)
+}
+
+var newConfigTests = []struct {
+	in  map[string]string
+	cfg *sp.Config
+	err error
+}{
+	{map[string]string{}, nil, errors.New("BaseUrl is required for api config")},
+	{map[string]string{"baseurl": "http://example.com"}, nil, errors.New("ApiKey is required for api config")},
+	{map[string]string{"baseurl": "http://example.com", "apikey": "foo"}, &sp.Config{BaseUrl: "http://example.com", ApiKey: "foo"}, nil},
+}
+
+func TestNewConfig(t *testing.T) {
+	var cfg *sp.Config
+	var err error
+	for idx, test := range newConfigTests {
+		cfg, err = sp.NewConfig(test.in)
+		if err == nil && test.err != nil || err != nil && test.err == nil {
+			t.Errorf("NewConfig[%d] => err %q, want %q", idx, err, test.err)
+		} else if err != nil && err.Error() != test.err.Error() {
+			t.Errorf("NewConfig[%d] => err %q, want %q", idx, err, test.err)
+		} else if cfg == nil && test.cfg != nil || cfg != nil && test.cfg == nil {
+			t.Errorf("NewConfig[%d] => cfg %v, want %v", idx, cfg, test.cfg)
+		}
+	}
 }

--- a/common_test.go
+++ b/common_test.go
@@ -79,11 +79,11 @@ func TestNewConfig(t *testing.T) {
 }
 
 func TestJson(t *testing.T) {
-	var e = &sp.Error{Message: "This is fine."}
-	var exp = `{"message":"This is fine.","code":"","description":""}`
-	str := e.Json()
+	var e = sp.SPErrors([]sp.SPError{{Message: "This is fine."}})
+	var exp = `[{"message":"This is fine.","code":"","description":""}]`
+	str := e.Error()
 	if str != exp {
-		t.Errorf("*Error.Json => %q, want %q", str, exp)
+		t.Errorf("*SPError.Stringify => %q, want %q", str, exp)
 	}
 }
 

--- a/common_test.go
+++ b/common_test.go
@@ -87,6 +87,16 @@ func TestJson(t *testing.T) {
 	}
 }
 
+func TestDoRequest_BadMethod(t *testing.T) {
+	testSetup(t)
+	defer testTeardown()
+
+	_, err := testClient.DoRequest(nil, "💩", "", nil)
+	if err == nil {
+		t.Fatalf("bogus request method should fail")
+	}
+}
+
 var initTests = []struct {
 	api *sp.Client
 	cfg *sp.Config

--- a/common_test.go
+++ b/common_test.go
@@ -66,10 +66,8 @@ var newConfigTests = []struct {
 }
 
 func TestNewConfig(t *testing.T) {
-	var cfg *sp.Config
-	var err error
 	for idx, test := range newConfigTests {
-		cfg, err = sp.NewConfig(test.in)
+		cfg, err := sp.NewConfig(test.in)
 		if err == nil && test.err != nil || err != nil && test.err == nil {
 			t.Errorf("NewConfig[%d] => err %q, want %q", idx, err, test.err)
 		} else if err != nil && err.Error() != test.err.Error() {
@@ -79,3 +77,51 @@ func TestNewConfig(t *testing.T) {
 		}
 	}
 }
+
+func TestJson(t *testing.T) {
+	var e = &sp.Error{Message: "This is fine."}
+	var exp = `{"message":"This is fine.","code":"","description":""}`
+	str, err := e.Json()
+	if err != nil {
+		t.Errorf("*Error.Json() => err %v, want nil", err)
+	} else if str != exp {
+		t.Errorf("*Error.Json => %q, want %q", str, exp)
+	}
+}
+
+var initTests = []struct {
+	api *sp.Client
+	cfg *sp.Config
+	out *sp.Config
+	err error
+}{
+	{&sp.Client{}, &sp.Config{BaseUrl: ""}, &sp.Config{BaseUrl: "https://api.sparkpost.com"}, nil},
+	{&sp.Client{}, &sp.Config{BaseUrl: "http://api.sparkpost.com"}, nil, errors.New("API base url must be https!")},
+}
+
+func TestInit(t *testing.T) {
+	for idx, test := range initTests {
+		err := test.api.Init(test.cfg)
+		if err == nil && test.err != nil || err != nil && test.err == nil {
+			t.Errorf("Init[%d] => err %q, want %q", idx, err, test.err)
+		} else if err != nil && err.Error() != test.err.Error() {
+			t.Errorf("NewConfig[%d] => err %q, want %q", idx, err, test.err)
+		} else if test.out != nil && test.api.Config.BaseUrl != test.out.BaseUrl {
+			t.Errorf("Init[%d] => BaseUrl %q, want %q", idx, test.api.Config.BaseUrl, test.out.BaseUrl)
+		}
+	}
+}
+
+/* // either make headers public or can it entirely in favor of context
+func TestSetHeader(t *testing.T) {
+	var val string
+	var ok bool
+	cl := &sp.Client{}
+	cl.SetHeader("X-Foo", "Bar")
+	if val, ok = cl.headers["X-Foo"]; !ok {
+		t.Errorf("SetHeader => nil, want %q", "Bar")
+	} else if val != "Bar" {
+		t.Errorf("SetHeader => %q, want %q", val, "Bar")
+	}
+}
+*/

--- a/common_test.go
+++ b/common_test.go
@@ -109,17 +109,3 @@ func TestInit(t *testing.T) {
 		}
 	}
 }
-
-/* // either make headers public or can it entirely in favor of context
-func TestSetHeader(t *testing.T) {
-	var val string
-	var ok bool
-	cl := &sp.Client{}
-	cl.SetHeader("X-Foo", "Bar")
-	if val, ok = cl.headers["X-Foo"]; !ok {
-		t.Errorf("SetHeader => nil, want %q", "Bar")
-	} else if val != "Bar" {
-		t.Errorf("SetHeader => %q, want %q", val, "Bar")
-	}
-}
-*/

--- a/common_test.go
+++ b/common_test.go
@@ -81,10 +81,8 @@ func TestNewConfig(t *testing.T) {
 func TestJson(t *testing.T) {
 	var e = &sp.Error{Message: "This is fine."}
 	var exp = `{"message":"This is fine.","code":"","description":""}`
-	str, err := e.Json()
-	if err != nil {
-		t.Errorf("*Error.Json() => err %v, want nil", err)
-	} else if str != exp {
+	str := e.Json()
+	if str != exp {
 		t.Errorf("*Error.Json => %q, want %q", str, exp)
 	}
 }

--- a/subaccounts.go
+++ b/subaccounts.go
@@ -7,7 +7,7 @@ import (
 )
 
 // https://www.sparkpost.com/api#/reference/subaccounts
-var subaccountsPathFormat = "/api/v%d/subaccounts"
+var SubaccountsPathFormat = "/api/v%d/subaccounts"
 var availableGrants = []string{
 	"smtp/inject",
 	"sending_domains/manage",
@@ -69,7 +69,7 @@ func (c *Client) SubaccountCreateContext(ctx context.Context, s *Subaccount) (re
 		return
 	}
 
-	path := fmt.Sprintf(subaccountsPathFormat, c.Config.ApiVersion)
+	path := fmt.Sprintf(SubaccountsPathFormat, c.Config.ApiVersion)
 	url := fmt.Sprintf("%s%s", c.Config.BaseUrl, path)
 	res, err = c.HttpPost(ctx, url, jsonBytes)
 	if err != nil {
@@ -153,7 +153,7 @@ func (c *Client) SubaccountUpdateContext(ctx context.Context, s *Subaccount) (re
 		return
 	}
 
-	path := fmt.Sprintf(templatesPathFormat, c.Config.ApiVersion)
+	path := fmt.Sprintf(SubaccountsPathFormat, c.Config.ApiVersion)
 	url := fmt.Sprintf("%s%s/%s", c.Config.BaseUrl, path, s.ID)
 
 	res, err = c.HttpPut(ctx, url, jsonBytes)
@@ -198,7 +198,7 @@ func (c *Client) Subaccounts() (subaccounts []Subaccount, res *Response, err err
 
 // SubaccountsContext is the same as Subaccounts, and it allows the caller to provide a context
 func (c *Client) SubaccountsContext(ctx context.Context) (subaccounts []Subaccount, res *Response, err error) {
-	path := fmt.Sprintf(subaccountsPathFormat, c.Config.ApiVersion)
+	path := fmt.Sprintf(SubaccountsPathFormat, c.Config.ApiVersion)
 	url := fmt.Sprintf("%s%s", c.Config.BaseUrl, path)
 	res, err = c.HttpGet(ctx, url)
 	if err != nil {
@@ -252,7 +252,7 @@ func (c *Client) Subaccount(id int) (subaccount *Subaccount, res *Response, err 
 
 // SubaccountContext is the same as Subaccount, and it accepts a context.Context
 func (c *Client) SubaccountContext(ctx context.Context, id int) (subaccount *Subaccount, res *Response, err error) {
-	path := fmt.Sprintf(subaccountsPathFormat, c.Config.ApiVersion)
+	path := fmt.Sprintf(SubaccountsPathFormat, c.Config.ApiVersion)
 	u := fmt.Sprintf("%s%s/%d", c.Config.BaseUrl, path, id)
 	res, err = c.HttpGet(ctx, u)
 	if err != nil {

--- a/templates.go
+++ b/templates.go
@@ -396,19 +396,8 @@ func (c *Client) TemplatePreviewContext(ctx context.Context, id string, payload 
 		return
 	}
 
-	if len(res.Errors) > 0 {
-		// handle common errors
-		err = res.PrettyError("Template", "preview")
-		if err != nil {
-			return
-		}
-
-		if res.HTTP.StatusCode == 422 { // preview payload error
-			eobj := res.Errors[0]
-			err = fmt.Errorf("%s: %s\n%s", eobj.Code, eobj.Message, eobj.Description)
-		} else { // everything else
-			err = fmt.Errorf("%d: %s", res.HTTP.StatusCode, string(res.Body))
-		}
+	if res.HTTP.StatusCode != 200 {
+		err = res.Errors
 	}
 
 	return

--- a/templates.go
+++ b/templates.go
@@ -202,10 +202,8 @@ func (c *Client) TemplateCreateContext(ctx context.Context, t *Template) (id str
 		return
 	}
 
-	jsonBytes, err := json.Marshal(t)
-	if err != nil {
-		return
-	}
+	// A Template that makes it past Validate() will always Marshal
+	jsonBytes, _ := json.Marshal(t)
 
 	path := fmt.Sprintf(TemplatesPathFormat, c.Config.ApiVersion)
 	url := fmt.Sprintf("%s%s", c.Config.BaseUrl, path)

--- a/templates.go
+++ b/templates.go
@@ -226,20 +226,8 @@ func (c *Client) TemplateCreateContext(ctx context.Context, t *Template) (id str
 		if !ok {
 			err = fmt.Errorf("Unexpected response to Template creation")
 		}
-
-	} else if len(res.Errors) > 0 {
-		// handle common errors
-		err = res.PrettyError("Template", "create")
-		if err != nil {
-			return
-		}
-
-		if res.HTTP.StatusCode == 422 { // template syntax error
-			eobj := res.Errors[0]
-			err = fmt.Errorf("%s: %s\n%s", eobj.Code, eobj.Message, eobj.Description)
-		} else { // everything else
-			err = fmt.Errorf("%d: %s", res.HTTP.StatusCode, string(res.Body))
-		}
+	} else {
+		err = res.Errors
 	}
 
 	return
@@ -287,19 +275,8 @@ func (c *Client) TemplateUpdateContext(ctx context.Context, t *Template) (res *R
 	if res.HTTP.StatusCode == 200 {
 		return
 
-	} else if len(res.Errors) > 0 {
-		// handle common errors
-		err = res.PrettyError("Template", "update")
-		if err != nil {
-			return
-		}
-
-		// handle template-specific ones
-		if res.HTTP.StatusCode == 409 {
-			err = fmt.Errorf("Template with id [%s] is in use by msg generation", t.ID)
-		} else { // everything else
-			err = fmt.Errorf("%d: %s", res.HTTP.StatusCode, string(res.Body))
-		}
+	} else {
+		err = res.Errors
 	}
 
 	return

--- a/templates.go
+++ b/templates.go
@@ -10,7 +10,7 @@ import (
 )
 
 // https://www.sparkpost.com/api#/reference/templates
-var templatesPathFormat = "/api/v%d/templates"
+var TemplatesPathFormat = "/api/v%d/templates"
 
 // Template is the JSON structure accepted by and returned from the SparkPost Templates API.
 // It's mostly metadata at this level - see Content and Options for more detail.
@@ -207,7 +207,7 @@ func (c *Client) TemplateCreateContext(ctx context.Context, t *Template) (id str
 		return
 	}
 
-	path := fmt.Sprintf(templatesPathFormat, c.Config.ApiVersion)
+	path := fmt.Sprintf(TemplatesPathFormat, c.Config.ApiVersion)
 	url := fmt.Sprintf("%s%s", c.Config.BaseUrl, path)
 	res, err = c.HttpPost(ctx, url, jsonBytes)
 	if err != nil {
@@ -274,7 +274,7 @@ func (c *Client) TemplateUpdateContext(ctx context.Context, t *Template) (res *R
 		return
 	}
 
-	path := fmt.Sprintf(templatesPathFormat, c.Config.ApiVersion)
+	path := fmt.Sprintf(TemplatesPathFormat, c.Config.ApiVersion)
 	url := fmt.Sprintf("%s%s/%s?update_published=%t", c.Config.BaseUrl, path, t.ID, t.Published)
 
 	res, err = c.HttpPut(ctx, url, jsonBytes)
@@ -319,7 +319,7 @@ func (c *Client) Templates() ([]Template, *Response, error) {
 
 // TemplatesContext is the same as Templates, and it allows the caller to provide a context
 func (c *Client) TemplatesContext(ctx context.Context) ([]Template, *Response, error) {
-	path := fmt.Sprintf(templatesPathFormat, c.Config.ApiVersion)
+	path := fmt.Sprintf(TemplatesPathFormat, c.Config.ApiVersion)
 	url := fmt.Sprintf("%s%s", c.Config.BaseUrl, path)
 	res, err := c.HttpGet(ctx, url)
 	if err != nil {
@@ -373,7 +373,7 @@ func (c *Client) TemplateDeleteContext(ctx context.Context, id string) (res *Res
 		return
 	}
 
-	path := fmt.Sprintf(templatesPathFormat, c.Config.ApiVersion)
+	path := fmt.Sprintf(TemplatesPathFormat, c.Config.ApiVersion)
 	url := fmt.Sprintf("%s%s/%s", c.Config.BaseUrl, path, id)
 	res, err = c.HttpDelete(ctx, url)
 	if err != nil {
@@ -431,7 +431,7 @@ func (c *Client) TemplatePreviewContext(ctx context.Context, id string, payload 
 		return
 	}
 
-	path := fmt.Sprintf(templatesPathFormat, c.Config.ApiVersion)
+	path := fmt.Sprintf(TemplatesPathFormat, c.Config.ApiVersion)
 	url := fmt.Sprintf("%s%s/%s/preview", c.Config.BaseUrl, path, id)
 	res, err = c.HttpPost(ctx, url, jsonBytes)
 	if err != nil {

--- a/templates.go
+++ b/templates.go
@@ -266,17 +266,16 @@ func (c *Client) TemplateUpdateContext(ctx context.Context, t *Template) (res *R
 		return
 	}
 
-	if res.AssertJson() == nil {
-		if err = res.ParseResponse(); err != nil {
-			return
-		}
+	if err = res.AssertJson(); err != nil {
+		return
 	}
 
 	if res.HTTP.StatusCode == 200 {
 		return
-
 	} else {
-		err = res.Errors
+		if err = res.ParseResponse(); err == nil {
+			err = res.Errors
+		}
 	}
 
 	return
@@ -290,7 +289,7 @@ func (c *Client) Templates() ([]Template, *Response, error) {
 // TemplatesContext is the same as Templates, and it allows the caller to provide a context
 func (c *Client) TemplatesContext(ctx context.Context) ([]Template, *Response, error) {
 	path := fmt.Sprintf(TemplatesPathFormat, c.Config.ApiVersion)
-	url := fmt.Sprintf("%s%s", c.Config.BaseUrl, path)
+	url := c.Config.BaseUrl + path
 	res, err := c.HttpGet(ctx, url)
 	if err != nil {
 		return nil, nil, err
@@ -319,13 +318,7 @@ func (c *Client) TemplatesContext(ctx context.Context) ([]Template, *Response, e
 		if err != nil {
 			return nil, res, err
 		}
-		if len(res.Errors) > 0 {
-			err = res.PrettyError("Template", "list")
-			if err != nil {
-				return nil, res, err
-			}
-		}
-		err = fmt.Errorf("%d: %s", res.HTTP.StatusCode, string(res.Body))
+		err = res.Errors
 	}
 
 	return nil, res, err

--- a/templates.go
+++ b/templates.go
@@ -352,22 +352,8 @@ func (c *Client) TemplateDeleteContext(ctx context.Context, id string) (res *Res
 		return
 	}
 
-	if res.HTTP.StatusCode == 200 {
-		return
-
-	} else if len(res.Errors) > 0 {
-		// handle common errors
-		err = res.PrettyError("Template", "delete")
-		if err != nil {
-			return
-		}
-
-		// handle template-specific ones
-		if res.HTTP.StatusCode == 409 {
-			err = fmt.Errorf("Template with id [%s] is in use by msg generation", id)
-		} else { // everything else
-			err = fmt.Errorf("%d: %s", res.HTTP.StatusCode, string(res.Body))
-		}
+	if res.HTTP.StatusCode != 200 {
+		err = res.Errors
 	}
 
 	return

--- a/templates.go
+++ b/templates.go
@@ -179,11 +179,6 @@ func (t *Template) Validate() error {
 	return nil
 }
 
-// SetHeaders is a convenience method which sets Template.Content.Headers to the provided map.
-func (t *Template) SetHeaders(headers map[string]string) {
-	t.Content.Headers = headers
-}
-
 // TemplateCreate accepts a populated Template object, validates its Contents,
 // and performs an API call against the configured endpoint.
 func (c *Client) TemplateCreate(t *Template) (id string, res *Response, err error) {

--- a/templates.go
+++ b/templates.go
@@ -279,8 +279,7 @@ func (c *Client) TemplateUpdateContext(ctx context.Context, t *Template) (res *R
 	}
 
 	if res.AssertJson() == nil {
-		err = res.ParseResponse()
-		if err != nil {
+		if err = res.ParseResponse(); err != nil {
 			return
 		}
 	}

--- a/templates_test.go
+++ b/templates_test.go
@@ -16,6 +16,7 @@ var templateFromValidationTests = []struct {
 	{sp.From{"a@b.com", "A B"}, nil, sp.From{"a@b.com", "A B"}},
 	{sp.Address{"a@b.com", "A B", "c@d.com"}, nil, sp.From{"a@b.com", "A B"}},
 	{"a@b.com", nil, sp.From{"a@b.com", ""}},
+	{nil, errors.New("unsupported Content.From value type [%!s(<nil>)]"), sp.From{"", ""}},
 	{[]byte("a@b.com"), errors.New("unsupported Content.From value type [[]uint8]"), sp.From{"", ""}},
 	{"", errors.New("Content.From may not be empty"), sp.From{"", ""}},
 	{map[string]interface{}{"name": "A B", "email": "a@b.com"}, nil, sp.From{"a@b.com", "A B"}},

--- a/templates_test.go
+++ b/templates_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	sp "github.com/SparkPost/gosparkpost"
-	"github.com/SparkPost/gosparkpost/test"
 )
 
 func TestTemplateValidation(t *testing.T) {
@@ -57,6 +56,11 @@ func TestTemplateValidation(t *testing.T) {
 	if "" != f.Name {
 		t.Error(fmt.Errorf("expected name to be blank"))
 		return
+	}
+	fromString = ""
+	_, err = sp.ParseFrom(fromString)
+	if err == nil {
+		t.Error(fmt.Errorf("Content.From should not be allowed!"))
 	}
 
 	fromMap1 := map[string]interface{}{
@@ -116,71 +120,4 @@ func TestTemplateValidation(t *testing.T) {
 		return
 	}
 
-}
-
-func TestTemplates(t *testing.T) {
-	if true {
-		// Temporarily disable test so TravisCI reports build success instead of test failure.
-		// NOTE: need travis to set sparkpost base urls etc, or mock http request
-		return
-	}
-
-	cfgMap, err := test.LoadConfig()
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	cfg, err := sp.NewConfig(cfgMap)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	var client sp.Client
-	err = client.Init(cfg)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	tlist, _, err := client.Templates()
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	t.Logf("templates listed: %+v", tlist)
-
-	content := sp.Content{
-		Subject: "this is a test template",
-		// NB: deliberate syntax error
-		//Text: "text part of the test template {{a}",
-		Text: "text part of the test template",
-		From: map[string]string{
-			"name":  "test name",
-			"email": "test@email.com",
-		},
-	}
-	template := &sp.Template{Content: content, Name: "test template"}
-
-	id, _, err := client.TemplateCreate(template)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	fmt.Printf("Created Template with id=%s\n", id)
-
-	d := map[string]interface{}{}
-	res, err := client.TemplatePreview(id, &sp.PreviewOptions{d})
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	fmt.Printf("Preview Template with id=%s and response %+v\n", id, res)
-
-	_, err = client.TemplateDelete(id)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	fmt.Printf("Deleted Template with id=%s\n", id)
 }

--- a/templates_test.go
+++ b/templates_test.go
@@ -12,25 +12,23 @@ import (
 	"github.com/pkg/errors"
 )
 
-var templateFromValidationTests = []struct {
-	in  interface{}
-	err error
-	out sp.From
-}{
-	{sp.From{"a@b.com", "A B"}, nil, sp.From{"a@b.com", "A B"}},
-	{sp.Address{"a@b.com", "A B", "c@d.com"}, nil, sp.From{"a@b.com", "A B"}},
-	{"a@b.com", nil, sp.From{"a@b.com", ""}},
-	{nil, errors.New("unsupported Content.From value type [%!s(<nil>)]"), sp.From{"", ""}},
-	{[]byte("a@b.com"), errors.New("unsupported Content.From value type [[]uint8]"), sp.From{"", ""}},
-	{"", errors.New("Content.From may not be empty"), sp.From{"", ""}},
-	{map[string]interface{}{"name": "A B", "email": "a@b.com"}, nil, sp.From{"a@b.com", "A B"}},
-	{map[string]interface{}{"name": 1, "email": "a@b.com"}, errors.New("strings are required for all Content.From values"),
-		sp.From{"a@b.com", ""}},
-	{map[string]string{"name": "A B", "email": "a@b.com"}, nil, sp.From{"a@b.com", "A B"}},
-}
-
 func TestTemplateFromValidation(t *testing.T) {
-	for idx, test := range templateFromValidationTests {
+	for idx, test := range []struct {
+		in  interface{}
+		err error
+		out sp.From
+	}{
+		{sp.From{"a@b.com", "A B"}, nil, sp.From{"a@b.com", "A B"}},
+		{sp.Address{"a@b.com", "A B", "c@d.com"}, nil, sp.From{"a@b.com", "A B"}},
+		{"a@b.com", nil, sp.From{"a@b.com", ""}},
+		{nil, errors.New("unsupported Content.From value type [%!s(<nil>)]"), sp.From{"", ""}},
+		{[]byte("a@b.com"), errors.New("unsupported Content.From value type [[]uint8]"), sp.From{"", ""}},
+		{"", errors.New("Content.From may not be empty"), sp.From{"", ""}},
+		{map[string]interface{}{"name": "A B", "email": "a@b.com"}, nil, sp.From{"a@b.com", "A B"}},
+		{map[string]interface{}{"name": 1, "email": "a@b.com"}, errors.New("strings are required for all Content.From values"),
+			sp.From{"a@b.com", ""}},
+		{map[string]string{"name": "A B", "email": "a@b.com"}, nil, sp.From{"a@b.com", "A B"}},
+	} {
 		f, err := sp.ParseFrom(test.in)
 		if err == nil && test.err != nil || err != nil && test.err == nil {
 			t.Errorf("ParseFrom[%d] => err %q, want %q", idx, err, test.err)
@@ -75,59 +73,57 @@ func TestTemplateOptions(t *testing.T) {
 	}
 }
 
-var templateValidationTests = []struct {
-	te  *sp.Template
-	err error
-	cmp func(te *sp.Template) bool
-}{
-	{nil, errors.New("Can't Validate a nil Template"), nil},
-	{&sp.Template{}, errors.New("Template requires a non-empty Content.Subject"), nil},
-	{&sp.Template{Content: sp.Content{Subject: "s"}}, errors.New("Template requires either Content.HTML or Content.Text"), nil},
-	{&sp.Template{Content: sp.Content{Subject: "s", HTML: "h", From: ""}},
-		errors.New("Content.From may not be empty"), nil},
-
-	{&sp.Template{ID: strings.Repeat("id", 33), Content: sp.Content{Subject: "s", HTML: "h", From: "f"}},
-		errors.New("Template id may not be longer than 64 bytes"), nil},
-	{&sp.Template{Name: strings.Repeat("name", 257), Content: sp.Content{Subject: "s", HTML: "h", From: "f"}},
-		errors.New("Template name may not be longer than 1024 bytes"), nil},
-	{&sp.Template{Description: strings.Repeat("desc", 257), Content: sp.Content{Subject: "s", HTML: "h", From: "f"}},
-		errors.New("Template description may not be longer than 1024 bytes"), nil},
-
-	{&sp.Template{
-		Content: sp.Content{
-			Subject: "s", HTML: "h", From: "f",
-			Attachments: []sp.Attachment{{Filename: strings.Repeat("f", 256)}},
-		}},
-		errors.Errorf("Attachment name length must be <= 255: [%s]", strings.Repeat("f", 256)), nil},
-	{&sp.Template{
-		Content: sp.Content{
-			Subject: "s", HTML: "h", From: "f",
-			Attachments: []sp.Attachment{{B64Data: "\r\n"}},
-		}},
-		errors.New("Attachment data may not contain line breaks [\\r\\n]"), nil},
-
-	{&sp.Template{
-		Content: sp.Content{
-			Subject: "s", HTML: "h", From: "f",
-			InlineImages: []sp.InlineImage{{Filename: strings.Repeat("f", 256)}},
-		}},
-		errors.Errorf("InlineImage name length must be <= 255: [%s]", strings.Repeat("f", 256)), nil},
-	{&sp.Template{
-		Content: sp.Content{
-			Subject: "s", HTML: "h", From: "f",
-			InlineImages: []sp.InlineImage{{B64Data: "\r\n"}},
-		}},
-		errors.New("InlineImage data may not contain line breaks [\\r\\n]"), nil},
-
-	{
-		&sp.Template{Content: sp.Content{EmailRFC822: "From:foo@example.com\r\n", Subject: "removeme"}},
-		nil,
-		func(te *sp.Template) bool { return te.Content.Subject == "" },
-	},
-}
-
 func TestTemplateValidation(t *testing.T) {
-	for idx, test := range templateValidationTests {
+	for idx, test := range []struct {
+		te  *sp.Template
+		err error
+		cmp func(te *sp.Template) bool
+	}{
+		{nil, errors.New("Can't Validate a nil Template"), nil},
+		{&sp.Template{}, errors.New("Template requires a non-empty Content.Subject"), nil},
+		{&sp.Template{Content: sp.Content{Subject: "s"}}, errors.New("Template requires either Content.HTML or Content.Text"), nil},
+		{&sp.Template{Content: sp.Content{Subject: "s", HTML: "h", From: ""}},
+			errors.New("Content.From may not be empty"), nil},
+
+		{&sp.Template{ID: strings.Repeat("id", 33), Content: sp.Content{Subject: "s", HTML: "h", From: "f"}},
+			errors.New("Template id may not be longer than 64 bytes"), nil},
+		{&sp.Template{Name: strings.Repeat("name", 257), Content: sp.Content{Subject: "s", HTML: "h", From: "f"}},
+			errors.New("Template name may not be longer than 1024 bytes"), nil},
+		{&sp.Template{Description: strings.Repeat("desc", 257), Content: sp.Content{Subject: "s", HTML: "h", From: "f"}},
+			errors.New("Template description may not be longer than 1024 bytes"), nil},
+
+		{&sp.Template{
+			Content: sp.Content{
+				Subject: "s", HTML: "h", From: "f",
+				Attachments: []sp.Attachment{{Filename: strings.Repeat("f", 256)}},
+			}},
+			errors.Errorf("Attachment name length must be <= 255: [%s]", strings.Repeat("f", 256)), nil},
+		{&sp.Template{
+			Content: sp.Content{
+				Subject: "s", HTML: "h", From: "f",
+				Attachments: []sp.Attachment{{B64Data: "\r\n"}},
+			}},
+			errors.New("Attachment data may not contain line breaks [\\r\\n]"), nil},
+
+		{&sp.Template{
+			Content: sp.Content{
+				Subject: "s", HTML: "h", From: "f",
+				InlineImages: []sp.InlineImage{{Filename: strings.Repeat("f", 256)}},
+			}},
+			errors.Errorf("InlineImage name length must be <= 255: [%s]", strings.Repeat("f", 256)), nil},
+		{&sp.Template{
+			Content: sp.Content{
+				Subject: "s", HTML: "h", From: "f",
+				InlineImages: []sp.InlineImage{{B64Data: "\r\n"}},
+			}},
+			errors.New("InlineImage data may not contain line breaks [\\r\\n]"), nil},
+
+		{
+			&sp.Template{Content: sp.Content{EmailRFC822: "From:foo@example.com\r\n", Subject: "removeme"}},
+			nil,
+			func(te *sp.Template) bool { return te.Content.Subject == "" },
+		},
+	} {
 		err := test.te.Validate()
 		if err == nil && test.err != nil || err != nil && test.err == nil {
 			t.Errorf("Template.Validate[%d] => err %q, want %q", idx, err, test.err)
@@ -139,40 +135,38 @@ func TestTemplateValidation(t *testing.T) {
 	}
 }
 
-var templateCreateTests = []struct {
-	in     *sp.Template
-	err    error
-	status int
-	json   string
-	id     string
-}{
-	{nil, errors.New("Create called with nil Template"), 0, "", ""},
-	{&sp.Template{}, errors.New("Template requires a non-empty Content.Subject"), 0, "", ""},
-	{&sp.Template{Content: sp.Content{Subject: "s", HTML: "h", From: "f"}},
-		errors.New("Unexpected response to Template creation (results)"),
-		200, `{"foo":{"id":"new-template"}}`, ""},
-	{&sp.Template{Content: sp.Content{Subject: "s", HTML: "h", From: "f"}},
-		errors.New("Unexpected response to Template creation"),
-		200, `{"results":{"ID":"new-template"}}`, ""},
-	{&sp.Template{Content: sp.Content{Subject: "s", HTML: "h", From: "f"}},
-		errors.New("parsing api response: unexpected end of JSON input"),
-		200, `{"results":{"ID":"new-template"}`, ""},
-
-	{&sp.Template{Content: sp.Content{Subject: "s{{", HTML: "h", From: "f"}},
-		sp.SPErrors([]sp.SPError{{
-			Message:     "substitution language syntax error in template content",
-			Description: "Error while compiling header Subject: substitution statement missing ending '}}'",
-			Code:        "3000",
-			Part:        "Header:Subject",
-		}}),
-		422, `{ "errors": [ { "message": "substitution language syntax error in template content", "description": "Error while compiling header Subject: substitution statement missing ending '}}'", "code": "3000", "part": "Header:Subject" } ] }`, ""},
-
-	{&sp.Template{Content: sp.Content{Subject: "s", HTML: "h", From: "f"}}, nil,
-		200, `{"results":{"id":"new-template"}}`, "new-template"},
-}
-
 func TestTemplateCreate(t *testing.T) {
-	for idx, test := range templateCreateTests {
+	for idx, test := range []struct {
+		in     *sp.Template
+		err    error
+		status int
+		json   string
+		id     string
+	}{
+		{nil, errors.New("Create called with nil Template"), 0, "", ""},
+		{&sp.Template{}, errors.New("Template requires a non-empty Content.Subject"), 0, "", ""},
+		{&sp.Template{Content: sp.Content{Subject: "s", HTML: "h", From: "f"}},
+			errors.New("Unexpected response to Template creation (results)"),
+			200, `{"foo":{"id":"new-template"}}`, ""},
+		{&sp.Template{Content: sp.Content{Subject: "s", HTML: "h", From: "f"}},
+			errors.New("Unexpected response to Template creation"),
+			200, `{"results":{"ID":"new-template"}}`, ""},
+		{&sp.Template{Content: sp.Content{Subject: "s", HTML: "h", From: "f"}},
+			errors.New("parsing api response: unexpected end of JSON input"),
+			200, `{"results":{"ID":"new-template"}`, ""},
+
+		{&sp.Template{Content: sp.Content{Subject: "s{{", HTML: "h", From: "f"}},
+			sp.SPErrors([]sp.SPError{{
+				Message:     "substitution language syntax error in template content",
+				Description: "Error while compiling header Subject: substitution statement missing ending '}}'",
+				Code:        "3000",
+				Part:        "Header:Subject",
+			}}),
+			422, `{ "errors": [ { "message": "substitution language syntax error in template content", "description": "Error while compiling header Subject: substitution statement missing ending '}}'", "code": "3000", "part": "Header:Subject" } ] }`, ""},
+
+		{&sp.Template{Content: sp.Content{Subject: "s", HTML: "h", From: "f"}}, nil,
+			200, `{"results":{"id":"new-template"}}`, "new-template"},
+	} {
 		testSetup(t)
 		defer testTeardown()
 
@@ -195,31 +189,29 @@ func TestTemplateCreate(t *testing.T) {
 	}
 }
 
-var templateUpdateTests = []struct {
-	in     *sp.Template
-	err    error
-	status int
-	json   string
-}{
-	{nil, errors.New("Update called with nil Template"), 0, ""},
-	{&sp.Template{ID: ""}, errors.New("Update called with blank id"), 0, ""},
-	{&sp.Template{ID: "id", Content: sp.Content{}}, errors.New("Template requires a non-empty Content.Subject"), 0, ""},
-	{&sp.Template{ID: "id", Content: sp.Content{Subject: "s", HTML: "h", From: "f"}}, errors.New("parsing api response: unexpected end of JSON input"), 0, `{ "errors": [ { "message": "truncated json" }`},
-
-	{&sp.Template{ID: "id", Content: sp.Content{Subject: "s{{", HTML: "h", From: "f"}},
-		sp.SPErrors([]sp.SPError{{
-			Message:     "substitution language syntax error in template content",
-			Description: "Error while compiling header Subject: substitution statement missing ending '}}'",
-			Code:        "3000",
-			Part:        "Header:Subject",
-		}}),
-		422, `{ "errors": [ { "message": "substitution language syntax error in template content", "description": "Error while compiling header Subject: substitution statement missing ending '}}'", "code": "3000", "part": "Header:Subject" } ] }`},
-
-	{&sp.Template{ID: "id", Content: sp.Content{Subject: "s", HTML: "h", From: "f"}}, nil, 200, ""},
-}
-
 func TestTemplateUpdate(t *testing.T) {
-	for idx, test := range templateUpdateTests {
+	for idx, test := range []struct {
+		in     *sp.Template
+		err    error
+		status int
+		json   string
+	}{
+		{nil, errors.New("Update called with nil Template"), 0, ""},
+		{&sp.Template{ID: ""}, errors.New("Update called with blank id"), 0, ""},
+		{&sp.Template{ID: "id", Content: sp.Content{}}, errors.New("Template requires a non-empty Content.Subject"), 0, ""},
+		{&sp.Template{ID: "id", Content: sp.Content{Subject: "s", HTML: "h", From: "f"}}, errors.New("parsing api response: unexpected end of JSON input"), 0, `{ "errors": [ { "message": "truncated json" }`},
+
+		{&sp.Template{ID: "id", Content: sp.Content{Subject: "s{{", HTML: "h", From: "f"}},
+			sp.SPErrors([]sp.SPError{{
+				Message:     "substitution language syntax error in template content",
+				Description: "Error while compiling header Subject: substitution statement missing ending '}}'",
+				Code:        "3000",
+				Part:        "Header:Subject",
+			}}),
+			422, `{ "errors": [ { "message": "substitution language syntax error in template content", "description": "Error while compiling header Subject: substitution statement missing ending '}}'", "code": "3000", "part": "Header:Subject" } ] }`},
+
+		{&sp.Template{ID: "id", Content: sp.Content{Subject: "s", HTML: "h", From: "f"}}, nil, 200, ""},
+	} {
 		testSetup(t)
 		defer testTeardown()
 
@@ -245,16 +237,30 @@ func TestTemplateUpdate(t *testing.T) {
 	}
 }
 
-var templatesTests = []struct {
-	err    error
-	status int
-	json   string
-}{}
-
 func TestTemplates(t *testing.T) {
-	for idx, test := range templatesTests {
+	for idx, test := range []struct {
+		err    error
+		status int
+		json   string
+	}{
+		{errors.New("parsing api response: unexpected end of JSON input"), 0, `{ "errors": [ { "message": "truncated json" }`},
+	} {
 		testSetup(t)
 		defer testTeardown()
 
+		path := fmt.Sprintf(sp.TemplatesPathFormat, testClient.Config.ApiVersion)
+		testMux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, "GET")
+			w.Header().Set("Content-Type", "application/json; charset=utf8")
+			w.WriteHeader(test.status)
+			w.Write([]byte(test.json))
+		})
+
+		_, _, err := testClient.Templates()
+		if err == nil && test.err != nil || err != nil && test.err == nil {
+			t.Errorf("Templates[%d] => err %q want %q", idx, err, test.err)
+		} else if err != nil && err.Error() != test.err.Error() {
+			t.Errorf("Templates[%d] => err %q want %q", idx, err, test.err)
+		}
 	}
 }

--- a/templates_test.go
+++ b/templates_test.go
@@ -5,119 +5,68 @@ import (
 	"testing"
 
 	sp "github.com/SparkPost/gosparkpost"
+	"github.com/pkg/errors"
 )
 
+var templateFromValidationTests = []struct {
+	in  interface{}
+	err error
+	out sp.From
+}{
+	{sp.From{"a@b.com", "A B"}, nil, sp.From{"a@b.com", "A B"}},
+	{sp.Address{"a@b.com", "A B", "c@d.com"}, nil, sp.From{"a@b.com", "A B"}},
+	{"a@b.com", nil, sp.From{"a@b.com", ""}},
+	{[]byte("a@b.com"), errors.New("unsupported Content.From value type [[]uint8]"), sp.From{"", ""}},
+	{"", errors.New("Content.From may not be empty"), sp.From{"", ""}},
+	{map[string]interface{}{"name": "A B", "email": "a@b.com"}, nil, sp.From{"a@b.com", "A B"}},
+	{map[string]interface{}{"name": 1, "email": "a@b.com"}, errors.New("strings are required for all Content.From values"),
+		sp.From{"a@b.com", ""}},
+	{map[string]string{"name": "A B", "email": "a@b.com"}, nil, sp.From{"a@b.com", "A B"}},
+}
+
+func TestTemplateFromValidation(t *testing.T) {
+	for idx, test := range templateFromValidationTests {
+		f, err := sp.ParseFrom(test.in)
+		if err == nil && test.err != nil || err != nil && test.err == nil {
+			t.Errorf("ParseFrom[%d] => err %q, want %q", idx, err, test.err)
+		} else if err != nil && err.Error() != test.err.Error() {
+			t.Errorf("ParseFrom[%d] => err %q, want %q", idx, err, test.err)
+		} else if f.Email != test.out.Email {
+			t.Errorf("ParseFrom[%d] => Email %q, want %q", idx, f.Email, test.out.Email)
+		} else if f.Name != test.out.Name {
+			t.Errorf("ParseFrom[%d] => Name %q, want %q", idx, f.Name, test.out.Name)
+		}
+	}
+}
+
+var templateValidationTests = []struct {
+	te  *sp.Template
+	err error
+	cmp func(te *sp.Template) bool
+}{
+	{nil, errors.New("Can't Validate a nil Template"), nil},
+	{&sp.Template{}, errors.New("Template requires a non-empty Content.Subject"), nil},
+	{&sp.Template{Content: sp.Content{Subject: "s"}}, errors.New("Template requires either Content.HTML or Content.Text"), nil},
+	{&sp.Template{Content: sp.Content{Subject: "s", HTML: "h", From: ""}},
+		errors.New("Content.From may not be empty"), nil,
+	},
+
+	{
+		&sp.Template{Content: sp.Content{EmailRFC822: "From:foo@example.com\r\n", Subject: "removeme"}},
+		nil,
+		func(te *sp.Template) bool { return te.Content.Subject == "" },
+	},
+}
+
 func TestTemplateValidation(t *testing.T) {
-	fromStruct := sp.From{"a@b.com", "A B"}
-	f, err := sp.ParseFrom(fromStruct)
-	if err != nil {
-		t.Error(err)
-		return
+	for idx, test := range templateValidationTests {
+		err := test.te.Validate()
+		if err == nil && test.err != nil || err != nil && test.err == nil {
+			t.Errorf("Template.Validate[%d] => err %q, want %q", idx, err, test.err)
+		} else if err != nil && err.Error() != test.err.Error() {
+			t.Errorf("Template.Validate[%d] => err %q, want %q", idx, err, test.err)
+		} else if test.cmp != nil && test.cmp(test.te) == false {
+			t.Errorf("Template.Validate[%d] => failed post-condition check for %q", test.te)
+		}
 	}
-	if fromStruct.Email != f.Email {
-		t.Error(fmt.Errorf("expected email [%s] didn't match actual [%s]",
-			fromStruct.Email, f.Email))
-		return
-	}
-	if fromStruct.Name != f.Name {
-		t.Error(fmt.Errorf("expected name [%s] didn't match actual [%s]",
-			fromStruct.Name, f.Name))
-		return
-	}
-
-	addrStruct := sp.Address{"a@b.com", "A B", "c@d.com"}
-	f, err = sp.ParseFrom(addrStruct)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	if addrStruct.Email != f.Email {
-		t.Error(fmt.Errorf("expected email [%s] didn't match actual [%s]",
-			addrStruct.Email, f.Email))
-		return
-	}
-	if addrStruct.Name != f.Name {
-		t.Error(fmt.Errorf("expected name [%s] didn't match actual [%s]",
-			addrStruct.Name, f.Name))
-		return
-	}
-
-	fromString := "a@b.com"
-	f, err = sp.ParseFrom(fromString)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	if fromString != f.Email {
-		t.Error(fmt.Errorf("expected email [%s] didn't match actual [%s]",
-			fromString, f.Email))
-		return
-	}
-	if "" != f.Name {
-		t.Error(fmt.Errorf("expected name to be blank"))
-		return
-	}
-	fromString = ""
-	_, err = sp.ParseFrom(fromString)
-	if err == nil {
-		t.Error(fmt.Errorf("Content.From should not be allowed!"))
-	}
-
-	fromMap1 := map[string]interface{}{
-		"name":  "A B",
-		"email": "a@b.com",
-	}
-	f, err = sp.ParseFrom(fromMap1)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	// ParseFrom will bail if these aren't strings
-	fromString, _ = fromMap1["email"].(string)
-	if fromString != f.Email {
-		t.Error(fmt.Errorf("expected email [%s] didn't match actual [%s]",
-			fromString, f.Email))
-		return
-	}
-	nameString, _ := fromMap1["name"].(string)
-	if nameString != f.Name {
-		t.Error(fmt.Errorf("expected name [%s] didn't match actual [%s]",
-			nameString, f.Name))
-		return
-	}
-
-	fromMap1["name"] = 1
-	f, err = sp.ParseFrom(fromMap1)
-	if err == nil {
-		t.Error(fmt.Errorf("failed to detect non-string name"))
-		return
-	}
-
-	fromMap2 := map[string]string{
-		"name":  "A B",
-		"email": "a@b.com",
-	}
-	f, err = sp.ParseFrom(fromMap2)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	if fromMap2["email"] != f.Email {
-		t.Error(fmt.Errorf("expected email [%s] didn't match actual [%s]",
-			fromMap2["email"], f.Email))
-		return
-	}
-	if fromMap2["name"] != f.Name {
-		t.Error(fmt.Errorf("expected name [%s] didn't match actual [%s]",
-			fromMap2["name"], f.Name))
-		return
-	}
-
-	fromBytes := []byte("a@b.com")
-	f, err = sp.ParseFrom(fromBytes)
-	if err == nil {
-		t.Error(fmt.Errorf("failed to detect unsupported type"))
-		return
-	}
-
 }

--- a/templates_test.go
+++ b/templates_test.go
@@ -228,6 +228,9 @@ func TestTemplates(t *testing.T) {
 		json   string
 	}{
 		{errors.New("parsing api response: unexpected end of JSON input"), 0, `{ "errors": [ { "message": "truncated json" }`},
+		{errors.New("[{\"message\":\"truncated json\",\"code\":\"\",\"description\":\"\"}]"), 0, `{ "errors": [ { "message": "truncated json" } ] }`},
+		{nil, 200, `{ "results": [ { "description": "A test message from SparkPost.com", "id": "my-first-email", "last_update_time": "2006-01-02T15:04:05+00:00", "name": "My First Email", "published": false } ] }`},
+		{errors.New("Unexpected response to Template list"), 200, `{ "foo": [ { "description": "A malformed message from SparkPost.com" } ] }`},
 	} {
 		testSetup(t)
 		defer testTeardown()

--- a/templates_test.go
+++ b/templates_test.go
@@ -244,3 +244,27 @@ func TestTemplates(t *testing.T) {
 		}
 	}
 }
+
+func TestTemplateDelete(t *testing.T) {
+	for idx, test := range []struct {
+		id     string
+		err    error
+		status int
+		json   string
+	}{
+		{"", errors.New("Delete called with blank id"), 0, ""},
+		{"nope", errors.New("[{\"message\":\"Resource could not be found\",\"code\":\"\",\"description\":\"\"}]"), 404, `{ "errors": [ { "message": "Resource could not be found" } ] }`},
+		{"id", nil, 200, "{}"},
+	} {
+		testSetup(t)
+		defer testTeardown()
+		mockRestResponseBuilderFormat(t, "DELETE", test.status, sp.TemplatesPathFormat+"/"+test.id, test.json)
+
+		_, err := testClient.TemplateDelete(test.id)
+		if err == nil && test.err != nil || err != nil && test.err == nil {
+			t.Errorf("TemplateDelete[%d] => err %q want %q", idx, err, test.err)
+		} else if err != nil && err.Error() != test.err.Error() {
+			t.Errorf("TemplateDelete[%d] => err %q want %q", idx, err, test.err)
+		}
+	}
+}

--- a/templates_test.go
+++ b/templates_test.go
@@ -3,8 +3,6 @@ package gosparkpost_test
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
-	"net/http"
 	"strings"
 	"testing"
 
@@ -169,14 +167,7 @@ func TestTemplateCreate(t *testing.T) {
 	} {
 		testSetup(t)
 		defer testTeardown()
-
-		path := fmt.Sprintf(sp.TemplatesPathFormat, testClient.Config.ApiVersion)
-		testMux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-			testMethod(t, r, "POST")
-			w.Header().Set("Content-Type", "application/json; charset=utf8")
-			w.WriteHeader(test.status)
-			w.Write([]byte(test.json))
-		})
+		mockRestResponseBuilderFormat(t, "POST", test.status, sp.TemplatesPathFormat, test.json)
 
 		id, _, err := testClient.TemplateCreate(test.in)
 		if err == nil && test.err != nil || err != nil && test.err == nil {
@@ -219,19 +210,12 @@ func TestTemplateUpdate(t *testing.T) {
 		if test.in != nil {
 			id = test.in.ID
 		}
-		path := fmt.Sprintf(sp.TemplatesPathFormat+"/"+id, testClient.Config.ApiVersion)
-		testMux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-			testMethod(t, r, "PUT")
-			w.Header().Set("Content-Type", "application/json; charset=utf8")
-			w.WriteHeader(test.status)
-			w.Write([]byte(test.json))
-		})
+		mockRestResponseBuilderFormat(t, "PUT", test.status, sp.TemplatesPathFormat+"/"+id, test.json)
 
 		_, err := testClient.TemplateUpdate(test.in)
 		if err == nil && test.err != nil || err != nil && test.err == nil {
 			t.Errorf("TemplateUpdate[%d] => err %q want %q", idx, err, test.err)
 		} else if err != nil && err.Error() != test.err.Error() {
-			t.Logf("%+v")
 			t.Errorf("TemplateUpdate[%d] => err %q want %q", idx, err, test.err)
 		}
 	}
@@ -247,14 +231,7 @@ func TestTemplates(t *testing.T) {
 	} {
 		testSetup(t)
 		defer testTeardown()
-
-		path := fmt.Sprintf(sp.TemplatesPathFormat, testClient.Config.ApiVersion)
-		testMux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-			testMethod(t, r, "GET")
-			w.Header().Set("Content-Type", "application/json; charset=utf8")
-			w.WriteHeader(test.status)
-			w.Write([]byte(test.json))
-		})
+		mockRestResponseBuilderFormat(t, "GET", test.status, sp.TemplatesPathFormat, test.json)
 
 		_, _, err := testClient.Templates()
 		if err == nil && test.err != nil || err != nil && test.err == nil {

--- a/transmissions_test.go
+++ b/transmissions_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	sp "github.com/SparkPost/gosparkpost"
-	"github.com/SparkPost/gosparkpost/test"
 )
 
 var transmissionSuccess string = `{
@@ -32,8 +31,10 @@ func TestTransmissions_Post_Success(t *testing.T) {
 		w.Write([]byte(transmissionSuccess))
 	})
 
+	testClient.Config.ApiKey = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 	// set some headers on the client
 	testClient.Headers.Add("X-Foo", "foo")
+	testClient.Headers.Add("X-Foo", "baz")
 	testClient.Headers.Add("X-Bar", "bar")
 	testClient.Headers.Add("X-Baz", "baz")
 	testClient.Headers.Del("X-Baz")
@@ -91,6 +92,9 @@ func TestTransmissions_Delete_Headers(t *testing.T) {
 		w.Write([]byte("{}"))
 	})
 
+	testClient.Config.Username = "testuser"
+	testClient.Config.Password = "testpass"
+
 	header := http.Header{}
 	header.Add("X-Foo", "bar")
 	ctx := context.WithValue(context.Background(), "http.Header", header)
@@ -146,108 +150,12 @@ func TestTransmissions_ByID_Success(t *testing.T) {
 		testFailVerbose(t, res, "Transmission GET failed")
 	}
 
+	res, err = testClient.TransmissionContext(nil, tx1)
+	if err != nil {
+		testFailVerbose(t, res, "Transmission GET failed")
+	}
+
 	if tx1.CampaignID != tx.CampaignID {
 		testFailVerbose(t, res, "CampaignIDs do not match")
 	}
-}
-
-func TestTransmissions(t *testing.T) {
-	if true {
-		// Temporarily disable test so TravisCI reports build success instead of test failure.
-		return
-	}
-
-	cfgMap, err := test.LoadConfig()
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	cfg, err := sp.NewConfig(cfgMap)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	var client sp.Client
-	err = client.Init(cfg)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	tlist, res, err := client.Transmissions(&sp.Transmission{CampaignID: "msys_smoke"})
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	t.Errorf("List: %d, %d entries", res.HTTP.StatusCode, len(tlist))
-	for _, tr := range tlist {
-		t.Errorf("%s: %s", tr.ID, tr.CampaignID)
-	}
-
-	// TODO: 404 from Transmission Create could mean either
-	// Recipient List or Content wasn't found - open doc ticket
-	// to make error message more specific
-
-	T := &sp.Transmission{
-		CampaignID: "msys_smoke",
-		ReturnPath: "dgray@messagesystems.com",
-		Recipients: []string{"dgray@messagesystems.com", "dgray@sparkpost.com"},
-		// Single-recipient Transmissions are transient - Retrieve will 404
-		//Recipients: []string{"dgray@messagesystems.com"},
-		Content: sp.Content{
-			Subject: "this is a test message",
-			HTML:    "this is the <b>HTML</b> body of the test message",
-			From: map[string]string{
-				"name":  "Dave Gray",
-				"email": "dgray@messagesystems.com",
-			},
-		},
-		Metadata: map[string]interface{}{
-			"binding": "example",
-		},
-	}
-	err = T.Validate()
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	id, _, err := client.Send(T)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	t.Errorf("Transmission created with id [%s]", id)
-	T.ID = id
-
-	tr := &sp.Transmission{ID: id}
-	res, err = client.Transmission(tr)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	if res != nil {
-		t.Errorf("Retrieve returned HTTP %s\n", res.HTTP.Status)
-		if len(res.Errors) > 0 {
-			for _, e := range res.Errors {
-				json := e.Json()
-				t.Errorf("%s\n", json)
-			}
-		} else {
-			t.Errorf("Transmission retrieved: %s=%s\n", tr.ID, tr.State)
-		}
-	}
-
-	tx1 := &sp.Transmission{ID: id}
-	res, err = client.TransmissionDelete(tx1)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	t.Errorf("Delete returned HTTP %s\n%s\n", res.HTTP.Status, res.Body)
-
 }

--- a/transmissions_test.go
+++ b/transmissions_test.go
@@ -32,6 +32,9 @@ func TestTransmissions_Post_Success(t *testing.T) {
 		w.Write([]byte(transmissionSuccess))
 	})
 
+	testClient.Headers.Add("X-Foo", "foo")
+	testClient.Headers.Add("X-Bar", "bar")
+	testClient.Headers.Del("X-Bar")
 	tx := &sp.Transmission{
 		CampaignID: "Post_Success",
 		ReturnPath: "returnpath@example.com",
@@ -50,6 +53,19 @@ func TestTransmissions_Post_Success(t *testing.T) {
 
 	if id != "11111111111111111" {
 		testFailVerbose(t, res, "Unexpected value for id! (expected: 11111111111111111, saw: %s)", id)
+	}
+
+	var reqDump string
+	var ok bool
+	if reqDump, ok = res.Verbose["http_requestdump"]; !ok {
+		testFailVerbose(t, res, "HTTP Request unavailable")
+	}
+
+	if !strings.Contains(reqDump, "X-Foo: foo") {
+		testFailVerbose(t, res, "Header set on Client not sent")
+	}
+	if strings.Contains(reqDump, "X-Bar: bar") {
+		testFailVerbose(t, res, "Header set on Client should not have been sent")
 	}
 }
 

--- a/transmissions_test.go
+++ b/transmissions_test.go
@@ -207,10 +207,7 @@ func TestTransmissions(t *testing.T) {
 		t.Errorf("Retrieve returned HTTP %s\n", res.HTTP.Status)
 		if len(res.Errors) > 0 {
 			for _, e := range res.Errors {
-				json, err := e.Json()
-				if err != nil {
-					t.Error(err)
-				}
+				json := e.Json()
 				t.Errorf("%s\n", json)
 			}
 		} else {


### PR DESCRIPTION
Here are some helpers for visualizing code coverage locally:

```
function gocover () {
  dir=${PWD##*/}
  day=$(date +"%Y%m%d")
  t="/tmp/${dir}.${day}"
  go test -race -coverprofile="$t" $@
  go tool cover -html="$t" -o="$t.html"
}

function gocovero () {
  dir=${PWD##*/}
  day=$(date +"%Y%m%d")
  t="/tmp/${dir}.${day}"
  go test -race -coverprofile="$t" $@
  go tool cover -html="$t" -o="$t.html"
  open "$t.html"
}
```