### PR TITLE
Issue 89 suppression list cursor support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 **/.*.swp
+.vscode
+
+**/*.test

--- a/common_test.go
+++ b/common_test.go
@@ -2,6 +2,8 @@ package gosparkpost_test
 
 import (
 	"crypto/tls"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -52,4 +54,13 @@ func testFailVerbose(t *testing.T, res *sp.Response, fmt string, args ...interfa
 		}
 	}
 	t.Fatalf(fmt, args...)
+}
+
+func loadTestFile(fileToLoad string) string {
+	b, err := ioutil.ReadFile(fileToLoad)
+	if err != nil {
+		fmt.Print(err)
+	}
+
+	return string(b)
 }

--- a/common_test.go
+++ b/common_test.go
@@ -2,10 +2,13 @@ package gosparkpost_test
 
 import (
 	"crypto/tls"
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"testing"
 
 	sp "github.com/SparkPost/gosparkpost"
@@ -63,4 +66,21 @@ func loadTestFile(t *testing.T, fileToLoad string) string {
 	}
 
 	return string(b)
+}
+
+func AreEqualJSON(s1, s2 string) (bool, error) {
+	var o1 interface{}
+	var o2 interface{}
+
+	var err error
+	err = json.Unmarshal([]byte(s1), &o1)
+	if err != nil {
+		return false, fmt.Errorf("Error mashalling string 1 :: %s", err.Error())
+	}
+	err = json.Unmarshal([]byte(s2), &o2)
+	if err != nil {
+		return false, fmt.Errorf("Error mashalling string 2 :: %s", err.Error())
+	}
+
+	return reflect.DeepEqual(o1, o2), nil
 }

--- a/common_test.go
+++ b/common_test.go
@@ -2,7 +2,6 @@ package gosparkpost_test
 
 import (
 	"crypto/tls"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -56,10 +55,11 @@ func testFailVerbose(t *testing.T, res *sp.Response, fmt string, args ...interfa
 	t.Fatalf(fmt, args...)
 }
 
-func loadTestFile(fileToLoad string) string {
+func loadTestFile(t *testing.T, fileToLoad string) string {
 	b, err := ioutil.ReadFile(fileToLoad)
+
 	if err != nil {
-		fmt.Print(err)
+		t.Fatalf("Failed to load test data: %v", err)
 	}
 
 	return string(b)

--- a/suppression_list.go
+++ b/suppression_list.go
@@ -133,12 +133,22 @@ func (c *Client) SuppressionDelete(email string) (res *Response, err error) {
 
 // SuppressionDeleteContext deletes an entry from the suppression list
 func (c *Client) SuppressionDeleteContext(ctx context.Context, email string) (res *Response, err error) {
+	if email == "" {
+		err = fmt.Errorf("Deleting a suppression entry requires an email address")
+		return nil, err
+	}
+
 	path := fmt.Sprintf(SuppressionListsPathFormat, c.Config.ApiVersion)
 	finalURL := fmt.Sprintf("%s%s/%s", c.Config.BaseUrl, path, email)
 
 	res, err = c.HttpDelete(ctx, finalURL)
 	if err != nil {
 		return res, err
+	}
+
+	// If there are errors the response has JSON otherwise it is empty
+	if res.AssertJson != nil {
+		res.ParseResponse()
 	}
 
 	if res.HTTP.StatusCode >= 200 && res.HTTP.StatusCode <= 299 {
@@ -169,9 +179,9 @@ func (c *Client) SuppressionUpsertContext(ctx context.Context, entries []Suppres
 	}
 
 	path := fmt.Sprintf(SuppressionListsPathFormat, c.Config.ApiVersion)
-	list := SuppressionPage{}
+	suppressionPage := SuppressionPage{}
 
-	jsonBytes, err := json.Marshal(list)
+	jsonBytes, err := json.Marshal(suppressionPage)
 	if err != nil {
 		return nil, err
 	}

--- a/suppression_list.go
+++ b/suppression_list.go
@@ -28,6 +28,15 @@ type SuppressionEntry struct {
 	Created          string `json:"created,omitempty"`
 }
 
+// WritableSuppressionEntry stores a recipient’s opt-out preferences. It is a list of recipient email addresses to which you do NOT want to send email.
+// https://developers.sparkpost.com/api/suppression-list.html#suppression-list-bulk-insert-update-put
+type WritableSuppressionEntry struct {
+	// Recipient is used when a list is returned
+	Recipient   string `json:"recipient,omitempty"`
+	Type        string `json:"type,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
 // SuppressionPage wraps suppression entries and response meta information
 type SuppressionPage struct {
 	client *Client
@@ -168,20 +177,25 @@ func (c *Client) SuppressionDeleteContext(ctx context.Context, email string) (re
 }
 
 // SuppressionUpsert adds an entry to the suppression, or updates the existing entry
-func (c *Client) SuppressionUpsert(entries []SuppressionEntry) (*Response, error) {
+func (c *Client) SuppressionUpsert(entries []WritableSuppressionEntry) (*Response, error) {
 	return c.SuppressionUpsertContext(context.Background(), entries)
 }
 
 // SuppressionUpsertContext is the same as SuppressionUpsert, and it accepts a context.Context
-func (c *Client) SuppressionUpsertContext(ctx context.Context, entries []SuppressionEntry) (*Response, error) {
+func (c *Client) SuppressionUpsertContext(ctx context.Context, entries []WritableSuppressionEntry) (*Response, error) {
 	if entries == nil {
 		return nil, fmt.Errorf("`entries` cannot be nil")
 	}
 
 	path := fmt.Sprintf(SuppressionListsPathFormat, c.Config.ApiVersion)
-	suppressionPage := SuppressionPage{}
 
-	jsonBytes, err := json.Marshal(suppressionPage)
+	type EntriesWrapper struct {
+		Recipients []WritableSuppressionEntry `json:"recipients,omitempty"`
+	}
+
+	entriesWrapper := EntriesWrapper{entries}
+
+	jsonBytes, err := json.Marshal(entriesWrapper)
 	if err != nil {
 		return nil, err
 	}

--- a/suppression_list.go
+++ b/suppression_list.go
@@ -257,6 +257,9 @@ func (c *Client) suppressionGet(ctx context.Context, finalURL string, sp *Suppre
 
 	// Parse expected response structure
 	err = json.Unmarshal(bodyBytes, sp)
+	if err != nil {
+		return res, err
+	}
 
 	// For usage convenience parse out common links
 	for _, link := range sp.Links {
@@ -276,9 +279,5 @@ func (c *Client) suppressionGet(ctx context.Context, finalURL string, sp *Suppre
 		sp.client = c
 	}
 
-	if err != nil {
-		return res, err
-	}
-
-	return res, err
+	return res, nil
 }

--- a/suppression_list.go
+++ b/suppression_list.go
@@ -147,7 +147,7 @@ func (c *Client) SuppressionDeleteContext(ctx context.Context, email string) (re
 	}
 
 	// If there are errors the response has JSON otherwise it is empty
-	if res.AssertJson != nil {
+	if res.AssertJson() == nil {
 		res.ParseResponse()
 	}
 

--- a/suppression_list_test.go
+++ b/suppression_list_test.go
@@ -2,19 +2,14 @@ package gosparkpost_test
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"testing"
 
 	sp "github.com/SparkPost/gosparkpost"
 )
 
-var suppressionNotFound string = `{
-	"errors": [
-		{
-			"message": "Recipient could not be found"
-		}
-	]
-}`
+var suppressionNotFound = loadTestFile("test_data/suppression_not_found_error.json")
 
 // Test parsing of "not found" case
 func TestSuppression_Get_notFound(t *testing.T) {
@@ -31,37 +26,27 @@ func TestSuppression_Get_notFound(t *testing.T) {
 	})
 
 	// hit our local handler
-	s, res, err := testClient.SuppressionList()
+	suppressionPage := &sp.SuppressionPage{}
+
+	res, err := testClient.SuppressionList(suppressionPage)
 	if err != nil {
 		testFailVerbose(t, res, "SuppressionList GET returned error: %v", err)
 	}
 
 	// basic content test
-	if s.Results != nil {
+	if suppressionPage.Results != nil {
 		testFailVerbose(t, res, "SuppressionList GET returned non-nil Results (error expected)")
-	} else if len(s.Results) != 0 {
-		testFailVerbose(t, res, "SuppressionList GET returned %d results, expected %d", len(s.Results), 0)
-	} else if len(res.Errors) != 1 {
-		testFailVerbose(t, res, "SuppressionList GET returned %d errors, expected %d", len(res.Errors), 1)
-	} else if res.Errors[0].Message != "Recipient could not be found" {
+	} else if len(suppressionPage.Results) != 0 {
+		testFailVerbose(t, res, "SuppressionList GET returned %d results, expected %d", len(suppressionPage.Results), 0)
+	} else if len(suppressionPage.Errors) != 1 {
+		testFailVerbose(t, res, "SuppressionList GET returned %d errors, expected %d", len(suppressionPage.Errors), 1)
+	} else if suppressionPage.Errors[0].Message != "Recipient could not be found" {
 		testFailVerbose(t, res, "SuppressionList GET Unmarshal error; saw [%v] expected [%v]",
 			res.Errors[0].Message, "Recipient could not be found")
 	}
 }
 
-var combinedSuppressionList string = `{
-  "results": [
-    {
-      "recipient": "rcpt_1@example.com",
-      "transactional": true,
-      "non_transactional": true,
-      "source": "Manually Added",
-      "description": "User requested to not receive any non-transactional emails.",
-      "created": "2016-01-01T12:00:00+00:00",
-      "updated": "2016-01-01T12:00:00+00:00"
-    }
-  ]
-}`
+var combinedSuppressionList = loadTestFile("test_data/suppression_combined.json")
 
 // Test parsing of combined suppression list results
 func TestSuppression_Get_combinedList(t *testing.T) {
@@ -96,30 +81,7 @@ func TestSuppression_Get_combinedList(t *testing.T) {
 	}
 }
 
-var separateSuppressionList string = `{
-  "results": [
-    {
-      "recipient": "rcpt_1@example.com",
-      "non_transactional": true,
-      "source": "Manually Added",
-      "type": "non_transactional",
-      "description": "User requested to not receive any non-transactional emails.",
-      "created": "2016-01-01T12:00:00+00:00",
-      "updated": "2016-01-01T12:00:00+00:00"
-    },
-    {
-      "recipient": "rcpt_1@example.com",
-      "transactional": true,
-      "source": "Bounce Rule",
-      "type": "transactional",
-      "description": "550: 550-5.1.1 Invalid Recipient",
-      "created": "2015-10-15T12:00:00+00:00",
-      "updated": "2015-10-15T12:00:00+00:00"
-    }
-  ],
-  "links": [],
-  "total_count": 2
-}`
+var separateSuppressionList = loadTestFile("test_data/suppression_seperate_lists.json")
 
 // Test parsing of separate suppression list results
 func TestSuppression_Get_separateList(t *testing.T) {
@@ -154,30 +116,7 @@ func TestSuppression_Get_separateList(t *testing.T) {
 	}
 }
 
-var suppressionListCursor string = `{
-  "results": [
-    {
-      "recipient": "rcpt_1@example.com",
-      "transactional": true,
-      "non_transactional": true,
-      "source": "Manually Added",
-      "description": "User requested to not receive any non-transactional emails.",
-      "created": "2016-01-01T12:00:00+00:00",
-      "updated": "2016-01-01T12:00:00+00:00"
-    }
-  ],
-  "links": [
-    {
-      "href": "The_HREF_Value1",
-      "rel": "first"
-    },
-    {
-      "href": "The_HREF_Value2",
-      "rel": "next"
-    }
-  ],
-  "total_count": 44
-}`
+var suppressionListCursor = loadTestFile("test_data/suppression_cursor.json")
 
 // Test parsing of separate suppression list results
 func TestSuppression_links(t *testing.T) {
@@ -219,4 +158,13 @@ func TestSuppression_links(t *testing.T) {
 		t.Error("SuppressionList GET returned invalid s.Links[1].Rel")
 	}
 
+}
+
+func loadTestFile(fileToLoad string) string {
+	b, err := ioutil.ReadFile(fileToLoad)
+	if err != nil {
+		fmt.Print(err)
+	}
+
+	return string(b)
 }

--- a/suppression_list_test.go
+++ b/suppression_list_test.go
@@ -396,17 +396,13 @@ func TestClient_SuppressionUpsert_bad_json(t *testing.T) {
 	var mockResponse = "{bad json}"
 	mockRestBuilderFormat(t, "PUT", sp.SuppressionListsPathFormat, mockResponse)
 
-	entry := sp.SuppressionEntry{
-		Recipient:        "john.doe@domain.com",
-		Description:      "entry description",
-		Source:           "manually created",
-		Type:             "non_transactional",
-		Created:          "2016-05-02T16:29:56+00:00",
-		Updated:          "2016-05-02T16:29:56+00:00",
-		NonTransactional: true,
+	entry := sp.WritableSuppressionEntry{
+		Recipient:   "john.doe@domain.com",
+		Description: "entry description",
+		Type:        "non_transactional",
 	}
 
-	entries := []sp.SuppressionEntry{
+	entries := []sp.WritableSuppressionEntry{
 		entry,
 	}
 
@@ -425,17 +421,13 @@ func TestClient_SuppressionUpsert_1_entry(t *testing.T) {
 	var mockResponse = "{}"
 	mockRestBuilderFormat(t, "PUT", sp.SuppressionListsPathFormat, mockResponse)
 
-	entry := sp.SuppressionEntry{
-		Recipient:        "john.doe@domain.com",
-		Description:      "entry description",
-		Source:           "manually created",
-		Type:             "non_transactional",
-		Created:          "2016-05-02T16:29:56+00:00",
-		Updated:          "2016-05-02T16:29:56+00:00",
-		NonTransactional: true,
+	entry := sp.WritableSuppressionEntry{
+		Recipient:   "john.doe@domain.com",
+		Description: "entry description",
+		Type:        "non_transactional",
 	}
 
-	entries := []sp.SuppressionEntry{
+	entries := []sp.WritableSuppressionEntry{
 		entry,
 	}
 
@@ -455,17 +447,13 @@ func TestClient_SuppressionUpsert_error_response(t *testing.T) {
 	status := http.StatusBadRequest
 	mockRestResponseBuilderFormat(t, "PUT", status, sp.SuppressionListsPathFormat, mockResponse)
 
-	entry := sp.SuppressionEntry{
-		Recipient:        "john.doe@domain.com",
-		Description:      "entry description",
-		Source:           "manually created",
-		Type:             "non_transactional",
-		Created:          "2016-05-02T16:29:56+00:00",
-		Updated:          "2016-05-02T16:29:56+00:00",
-		NonTransactional: true,
+	entry := sp.WritableSuppressionEntry{
+		Recipient:   "john.doe@domain.com",
+		Description: "entry description",
+		Type:        "non_transactional",
 	}
 
-	entries := []sp.SuppressionEntry{
+	entries := []sp.WritableSuppressionEntry{
 		entry,
 	}
 

--- a/suppression_list_test.go
+++ b/suppression_list_test.go
@@ -14,7 +14,7 @@ func TestUnmarshal_SupressionEvent(t *testing.T) {
 	testSetup(t)
 	defer testTeardown()
 
-	var suppressionEventString = loadTestFile("test_data/suppression_entry_simple.json")
+	var suppressionEventString = loadTestFile(t, "test_data/suppression_entry_simple.json")
 
 	suppressionEntry := &sp.SuppressionEntry{}
 	err := json.Unmarshal([]byte(suppressionEventString), suppressionEntry)
@@ -31,7 +31,7 @@ func TestSuppression_Get_notFound(t *testing.T) {
 	defer testTeardown()
 
 	// set up the response handler
-	var mockResponse = loadTestFile("test_data/suppression_not_found_error.json")
+	var mockResponse = loadTestFile(t, "test_data/suppression_not_found_error.json")
 	mockRestBuilderFormat(t, "GET", sp.SuppressionListsPathFormat, mockResponse)
 
 	// hit our local handler
@@ -59,7 +59,7 @@ func TestSuppression_Retrieve(t *testing.T) {
 	defer testTeardown()
 
 	// set up the response handler
-	var mockResponse = loadTestFile("test_data/suppression_retrieve.json")
+	var mockResponse = loadTestFile(t, "test_data/suppression_retrieve.json")
 	status := http.StatusOK
 	email := "john.doe@domain.com"
 	mockRestResponseBuilderFormat(t, "GET", status, sp.SuppressionListsPathFormat+"/"+email, mockResponse)
@@ -88,7 +88,7 @@ func TestSuppression_Error_Bad_Path(t *testing.T) {
 	defer testTeardown()
 
 	// set up the response handler
-	var mockResponse = loadTestFile("test_data/suppression_not_found_error.json")
+	var mockResponse = loadTestFile(t, "test_data/suppression_not_found_error.json")
 	mockRestBuilderFormat(t, "GET", "/bad/path", mockResponse)
 
 	// hit our local handler
@@ -144,7 +144,7 @@ func TestSuppression_Get_combinedList(t *testing.T) {
 	defer testTeardown()
 
 	// set up the response handler
-	var mockResponse = loadTestFile("test_data/suppression_combined.json")
+	var mockResponse = loadTestFile(t, "test_data/suppression_combined.json")
 	mockRestBuilderFormat(t, "GET", sp.SuppressionListsPathFormat, mockResponse)
 
 	// hit our local handler
@@ -174,7 +174,7 @@ func TestSuppression_Get_separateList(t *testing.T) {
 	defer testTeardown()
 
 	// set up the response handler
-	var mockResponse = loadTestFile("test_data/suppression_seperate_lists.json")
+	var mockResponse = loadTestFile(t, "test_data/suppression_seperate_lists.json")
 	mockRestBuilderFormat(t, "GET", sp.SuppressionListsPathFormat, mockResponse)
 
 	// hit our local handler
@@ -204,7 +204,7 @@ func TestSuppression_links(t *testing.T) {
 	defer testTeardown()
 
 	// set up the response handler
-	var mockResponse = loadTestFile("test_data/suppression_cursor.json")
+	var mockResponse = loadTestFile(t, "test_data/suppression_cursor.json")
 	mockRestBuilderFormat(t, "GET", sp.SuppressionListsPathFormat, mockResponse)
 
 	// hit our local handler
@@ -253,7 +253,7 @@ func TestSuppression_Empty_NextPage(t *testing.T) {
 	defer testTeardown()
 
 	// set up the response handler
-	var mockResponse = loadTestFile("test_data/suppression_single_page.json")
+	var mockResponse = loadTestFile(t, "test_data/suppression_single_page.json")
 	mockRestBuilderFormat(t, "GET", sp.SuppressionListsPathFormat, mockResponse)
 
 	// hit our local handler
@@ -284,10 +284,10 @@ func TestSuppression_NextPage(t *testing.T) {
 	defer testTeardown()
 
 	// set up the response handler
-	var mockResponse = loadTestFile("test_data/suppression_page1.json")
+	var mockResponse = loadTestFile(t, "test_data/suppression_page1.json")
 	mockRestBuilderFormat(t, "GET", sp.SuppressionListsPathFormat, mockResponse)
 
-	mockResponse = loadTestFile("test_data/suppression_page2.json")
+	mockResponse = loadTestFile(t, "test_data/suppression_page2.json")
 	mockRestBuilder(t, "GET", "/test_data/suppression_page2.json", mockResponse)
 
 	// hit our local handler
@@ -318,7 +318,7 @@ func TestSuppression_Search_combinedList(t *testing.T) {
 	defer testTeardown()
 
 	// set up the response handler
-	var mockResponse = loadTestFile("test_data/suppression_combined.json")
+	var mockResponse = loadTestFile(t, "test_data/suppression_combined.json")
 	mockRestBuilderFormat(t, "GET", sp.SuppressionListsPathFormat, mockResponse)
 
 	// hit our local handler
@@ -348,7 +348,7 @@ func TestSuppression_Search_params(t *testing.T) {
 	defer testTeardown()
 
 	// set up the response handler
-	var mockResponse = loadTestFile("test_data/suppression_combined.json")
+	var mockResponse = loadTestFile(t, "test_data/suppression_combined.json")
 	mockRestBuilderFormat(t, "GET", sp.SuppressionListsPathFormat, mockResponse)
 
 	// hit our local handler
@@ -451,7 +451,7 @@ func TestClient_SuppressionUpsert_error_response(t *testing.T) {
 	testSetup(t)
 	defer testTeardown()
 
-	var mockResponse = loadTestFile("test_data/suppression_not_found_error.json")
+	var mockResponse = loadTestFile(t, "test_data/suppression_not_found_error.json")
 	status := http.StatusBadRequest
 	mockRestResponseBuilderFormat(t, "PUT", status, sp.SuppressionListsPathFormat, mockResponse)
 
@@ -523,7 +523,7 @@ func TestClient_Suppression_Delete_Errors(t *testing.T) {
 
 	email := "test@test.com"
 	status := http.StatusBadRequest
-	var mockResponse = loadTestFile("test_data/suppression_not_found_error.json")
+	var mockResponse = loadTestFile(t, "test_data/suppression_not_found_error.json")
 	mockRestResponseBuilderFormat(t, "DELETE", status, sp.SuppressionListsPathFormat+"/"+email, mockResponse)
 
 	response, err := testClient.SuppressionDelete(email)

--- a/test_data/suppression_combined.json
+++ b/test_data/suppression_combined.json
@@ -1,0 +1,13 @@
+{
+    "results": [
+        {
+            "recipient": "rcpt_1@example.com",
+            "transactional": true,
+            "non_transactional": true,
+            "source": "Manually Added",
+            "description": "User requested to not receive any non-transactional emails.",
+            "created": "2016-01-01T12:00:00+00:00",
+            "updated": "2016-01-01T12:00:00+00:00"
+        }
+    ]
+}

--- a/test_data/suppression_cursor.json
+++ b/test_data/suppression_cursor.json
@@ -1,0 +1,24 @@
+{
+    "results": [
+        {
+            "recipient": "rcpt_1@example.com",
+            "transactional": true,
+            "non_transactional": true,
+            "source": "Manually Added",
+            "description": "User requested to not receive any non-transactional emails.",
+            "created": "2016-01-01T12:00:00+00:00",
+            "updated": "2016-01-01T12:00:00+00:00"
+        }
+    ],
+    "links": [
+        {
+            "href": "The_HREF_Value1",
+            "rel": "first"
+        },
+        {
+            "href": "The_HREF_Value2",
+            "rel": "next"
+        }
+    ],
+    "total_count": 44
+}

--- a/test_data/suppression_delete_no_email.json
+++ b/test_data/suppression_delete_no_email.json
@@ -1,0 +1,7 @@
+{
+  "errors": [
+    {
+      "message": "Resource could not be found"
+    }
+  ]
+}

--- a/test_data/suppression_entry_simple.json
+++ b/test_data/suppression_entry_simple.json
@@ -1,0 +1,9 @@
+ {
+      "recipient": "john.doe@domain.com",
+      "description": "entry description",
+      "source": "manually created",
+      "type": "non_transactional",
+      "created": "2016-05-02T16:29:56+00:00",
+      "updated": "2016-05-02T17:20:50+00:00",
+      "non_transactional": true
+    }

--- a/test_data/suppression_entry_simple.json
+++ b/test_data/suppression_entry_simple.json
@@ -1,9 +1,9 @@
  {
-      "recipient": "john.doe@domain.com",
-      "description": "entry description",
-      "source": "manually created",
-      "type": "non_transactional",
-      "created": "2016-05-02T16:29:56+00:00",
-      "updated": "2016-05-02T17:20:50+00:00",
-      "non_transactional": true
-    }
+    "recipient": "john.doe@domain.com",
+    "description": "entry description",
+    "source": "manually created",
+    "type": "non_transactional",
+    "created": "2016-05-02T16:29:56+00:00",
+    "updated": "2016-05-02T17:20:50+00:00",
+    "non_transactional": true
+}

--- a/test_data/suppression_entry_simple_request.json
+++ b/test_data/suppression_entry_simple_request.json
@@ -1,0 +1,9 @@
+{
+    "recipients": [
+        {
+            "recipient": "john.doe@domain.com",
+            "type": "non_transactional",
+            "description": "entry description"
+        }
+    ]
+}

--- a/test_data/suppression_not_found_error.json
+++ b/test_data/suppression_not_found_error.json
@@ -1,0 +1,7 @@
+{
+    "errors": [
+        {
+            "message": "Recipient could not be found"
+        }
+    ]
+}

--- a/test_data/suppression_page1.json
+++ b/test_data/suppression_page1.json
@@ -12,20 +12,17 @@
     ],
     "links": [
         {
-            "href": "The_HREF_first",
+            "href": "/test_data/suppression_page1.json",
             "rel": "first"
         },
         {
-            "href": "The_HREF_next",
+            "href": "/test_data/suppression_page2.json",
             "rel": "next"
-        },{
-            "href": "The_HREF_previous",
-            "rel": "previous"
         },
         {
-            "href": "The_HREF_last",
+            "href": "/test_data/suppression_pageLast.json",
             "rel": "last"
         }
     ],
-    "total_count": 44
+    "total_count": 3
 }

--- a/test_data/suppression_page2.json
+++ b/test_data/suppression_page2.json
@@ -1,7 +1,7 @@
 {
     "results": [
         {
-            "recipient": "rcpt_1@example.com",
+            "recipient": "rcpt_2@example.com",
             "transactional": true,
             "non_transactional": true,
             "source": "Manually Added",
@@ -12,20 +12,21 @@
     ],
     "links": [
         {
-            "href": "The_HREF_first",
+            "href": "/test_data/suppression_page1.json",
             "rel": "first"
         },
         {
-            "href": "The_HREF_next",
+            "href": "/test_data/suppression_pageLast.json",
             "rel": "next"
-        },{
-            "href": "The_HREF_previous",
+        },
+        {
+            "href": "/test_data/suppression_page1.json",
             "rel": "previous"
         },
         {
-            "href": "The_HREF_last",
+            "href": "/test_data/suppression_pageLast.json",
             "rel": "last"
         }
     ],
-    "total_count": 44
+    "total_count": 3
 }

--- a/test_data/suppression_pageLast.json
+++ b/test_data/suppression_pageLast.json
@@ -1,7 +1,7 @@
 {
     "results": [
         {
-            "recipient": "rcpt_1@example.com",
+            "recipient": "rcpt_3@example.com",
             "transactional": true,
             "non_transactional": true,
             "source": "Manually Added",
@@ -12,20 +12,17 @@
     ],
     "links": [
         {
-            "href": "The_HREF_first",
+            "href": "/test_data/suppression_page1.json",
             "rel": "first"
         },
         {
-            "href": "The_HREF_next",
-            "rel": "next"
-        },{
-            "href": "The_HREF_previous",
+            "href": "/test_data/suppression_page2.json",
             "rel": "previous"
         },
         {
-            "href": "The_HREF_last",
+            "href": "/test_data/suppression_pageLast.json",
             "rel": "last"
         }
     ],
-    "total_count": 44
+    "total_count": 3
 }

--- a/test_data/suppression_retrieve.json
+++ b/test_data/suppression_retrieve.json
@@ -1,0 +1,15 @@
+{
+    "results": [
+        {
+            "recipient": "john.doe@domain.com",
+            "description": "entry description",
+            "source": "manually created",
+            "type": "non_transactional",
+            "created": "2016-05-02T16:29:56+00:00",
+            "updated": "2016-05-02T17:20:50+00:00",
+            "non_transactional": true
+        }
+    ],
+    "links": [],
+    "total_count": 1
+}

--- a/test_data/suppression_seperate_lists.json
+++ b/test_data/suppression_seperate_lists.json
@@ -1,0 +1,24 @@
+{
+    "results": [
+        {
+            "recipient": "rcpt_1@example.com",
+            "non_transactional": true,
+            "source": "Manually Added",
+            "type": "non_transactional",
+            "description": "User requested to not receive any non-transactional emails.",
+            "created": "2016-01-01T12:00:00+00:00",
+            "updated": "2016-01-01T12:00:00+00:00"
+        },
+        {
+            "recipient": "rcpt_1@example.com",
+            "transactional": true,
+            "source": "Bounce Rule",
+            "type": "transactional",
+            "description": "550: 550-5.1.1 Invalid Recipient",
+            "created": "2015-10-15T12:00:00+00:00",
+            "updated": "2015-10-15T12:00:00+00:00"
+        }
+    ],
+    "links": [],
+    "total_count": 2
+}

--- a/test_data/suppression_single_page.json
+++ b/test_data/suppression_single_page.json
@@ -11,21 +11,7 @@
         }
     ],
     "links": [
-        {
-            "href": "The_HREF_first",
-            "rel": "first"
-        },
-        {
-            "href": "The_HREF_next",
-            "rel": "next"
-        },{
-            "href": "The_HREF_previous",
-            "rel": "previous"
-        },
-        {
-            "href": "The_HREF_last",
-            "rel": "last"
-        }
+       
     ],
-    "total_count": 44
+    "total_count": 1
 }


### PR DESCRIPTION
This PR is a continuation of issue #89.

## Changes

* Adds more unit tests (90% coverage)
* Changes suppression list interface to be more like the other interfaces
* adds a Next() method that enables cursor to walk through large result sets
* fixes all issues reported by lint tool
* fixes some bugs found during unit testing