### PR TITLE
Added json tag to From struct

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -55,8 +55,8 @@ type InlineImage Attachment
 // From describes the nested object way of specifying the From header.
 // Content.From can be specified this way, or as a plain string.
 type From struct {
-	Email string
-	Name  string
+	Email string `json:"email"`
+	Name  string `json:"name"`
 }
 
 // TmplOptions specifies settings to apply to this Template.


### PR DESCRIPTION
When using `From` struct (instead of string) in `Transmission.Content`, API response was :
``` 
{
"message":"required field is missing",
"code":"1400",
"description":"content.from.email is a required field"
}
```

`From` struct was not encoding the `Name` and `Email` fields when converting to JSON, so the request had capital letters.