### PR TITLE
client-side macro support

### DIFF
--- a/common.go
+++ b/common.go
@@ -35,6 +35,8 @@ type Client struct {
 	Config  *Config
 	Client  *http.Client
 	Headers *http.Header
+
+	macros map[string]Macro
 }
 
 var nonDigit *regexp.Regexp = regexp.MustCompile(`\D`)

--- a/macros.go
+++ b/macros.go
@@ -32,7 +32,6 @@ var wordChars = regexp.MustCompile(`^\w+$`)
 
 // RegisterMacro associates a Macro with a Client.
 // As with all changes to the Client, this is only safe to call before any potential concurrency.
-// Splitting of arguments can be done in the Macro Func if desired.
 // Everything between the Macro Name and the closing delimiter will be passed to the Func as a single string argument.
 func (c *Client) RegisterMacro(m *Macro) error {
 	if m == nil {
@@ -51,7 +50,8 @@ func (c *Client) RegisterMacro(m *Macro) error {
 }
 
 // Apply substitutes top-level string values from the Recipient's SubstitutionData and Metadata
-// (in that order) for placeholders in the provided string.
+// (in that order) for placeholders in the provided string. Nested substitution blocks will not
+// be interpreted, meaning that they will be passed along to the API.
 func (r *Recipient) Apply(in string) (string, error) {
 	if r == nil {
 		return in, nil
@@ -165,6 +165,10 @@ func (c *Client) ApplyMacros(in string, r *Recipient) (string, error) {
 	return strings.Join(chunks, ""), nil
 }
 
+// Tokenize splits a string that may contain Handlebars-style template code into
+// (you guessed it) tokens for further processing. Called by Client.ApplyMacros
+// and Recipient.Apply internally. Unless those functions do not meet your specific
+// needs, this function should not need to be called directly.
 func Tokenize(str string) (out []ContentToken, err error) {
 	strlen := len(str)
 	for {

--- a/macros.go
+++ b/macros.go
@@ -53,6 +53,10 @@ func (c *Client) RegisterMacro(m *Macro) error {
 // Apply substitutes top-level string values from the Recipient's SubstitutionData and Metadata
 // (in that order) for placeholders in the provided string.
 func (r *Recipient) Apply(in string) (string, error) {
+	if r == nil {
+		return in, nil
+	}
+
 	tokens, err := Tokenize(in)
 	if err != nil {
 		return "", err
@@ -68,12 +72,18 @@ func (r *Recipient) Apply(in string) (string, error) {
 	var ok bool
 	if r.SubstitutionData != nil {
 		if sub, ok = r.SubstitutionData.(map[string]interface{}); !ok {
-			return "", errors.Errorf("unexpected substitution data type for recipient %s", addr.Email)
+			switch itype := r.SubstitutionData.(type) {
+			default:
+				return "", errors.Errorf("unexpected substitution data type [%T] for recipient %s", itype, addr.Email)
+			}
 		}
 	}
 	if r.Metadata != nil {
 		if meta, ok = r.Metadata.(map[string]interface{}); !ok {
-			return "", errors.Errorf("unexpected metadata type for recipient %s", addr.Email)
+			switch itype := r.Metadata.(type) {
+			default:
+				return "", errors.Errorf("unexpected metadata type [%T] for recipient %s", itype, addr.Email)
+			}
 		}
 	}
 

--- a/macros.go
+++ b/macros.go
@@ -31,9 +31,9 @@ type ContentToken struct {
 var wordChars = regexp.MustCompile(`^\w+$`)
 
 // RegisterMacro associates a Macro with a Client.
-// The provided Macro.Func is wrapped so that its argument is the string between the Macro name and closing delimiter.
+// As with all changes to the Client, this is only safe to call before any potential concurrency.
 // Splitting of arguments can be done in the Macro Func if desired.
-// Everything between the Macro Name and the closing delimiter will be passed as the single string argument.
+// Everything between the Macro Name and the closing delimiter will be passed to the Func as a single string argument.
 func (c *Client) RegisterMacro(m *Macro) error {
 	if m == nil {
 		return errors.New(`can't add nil Macro`)

--- a/macros.go
+++ b/macros.go
@@ -146,9 +146,6 @@ func (c *Client) ApplyMacros(in string, r *Recipient) (string, error) {
 				// no client macro matches this block, pass it through
 				chunks[idx] = token.Text
 			}
-
-		default:
-			return "", errors.Errorf("unsupported token type %q", token.Type)
 		}
 	}
 

--- a/macros.go
+++ b/macros.go
@@ -143,7 +143,8 @@ func (c *Client) ApplyMacros(in string, r *Recipient) (string, error) {
 				}
 				chunks[idx] = m.Func(params)
 			} else {
-				return "", errors.Errorf("no such macro %q", atoms[0])
+				// no client macro matches this block, pass it through
+				chunks[idx] = token.Text
 			}
 
 		default:
@@ -192,7 +193,7 @@ func Tokenize(str string) (out []ContentToken, err error) {
 		}
 
 		if curlies != 0 {
-			return nil, errors.Errorf("mismatched curly braces near %s", str)
+			return nil, errors.Errorf("mismatched curly braces near %q", str)
 		}
 
 		out = append(out, ContentToken{

--- a/macros.go
+++ b/macros.go
@@ -1,0 +1,204 @@
+package gosparkpost
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Macro enables user-defined functions to run on Template.Content before sending to the SparkPost API.
+// This enables e.g. external content, locale-specific date formatting, and so on.
+type Macro struct {
+	Name string
+	Func func(string) string
+}
+
+const (
+	StaticToken = iota
+	MacroToken
+)
+
+// TokenType differentiates between static content and macros that require extra processing.
+type TokenType int
+
+// ContentToken represents a piece of content, with one of the types defined above.
+type ContentToken struct {
+	Type TokenType
+	Text string
+}
+
+var wordChars = regexp.MustCompile(`^\w+$`)
+
+// RegisterMacro associates a Macro with a Client.
+// The provided Macro.Func is wrapped so that its argument is the non-whitespace between the Macro name and closing delimiter.
+func (c *Client) RegisterMacro(m *Macro) error {
+	if m == nil {
+		return errors.New(`can't add nil Macro`)
+	} else if !wordChars.MatchString(m.Name) {
+		return errors.New(`Macro names must only contain \w characters`)
+	} else if m.Func == nil {
+		return errors.New(`Macro must have non-nil Func field`)
+	}
+
+	if c.macros == nil {
+		c.macros = map[string]Macro{}
+	}
+	c.macros[m.Name] = *m
+	return nil
+}
+
+// Apply substitutes top-level string values from the Recipients SubstitutionData and Metadata
+// (in that order) for placeholders in the provided string.
+func (r *Recipient) Apply(in string) (string, error) {
+	tokens, err := Tokenize(in)
+	if err != nil {
+		return "", err
+	}
+	chunks := make([]string, len(tokens))
+
+	addr, err := ParseAddress(r.Address)
+	if err != nil {
+		return "", errors.Wrap(err, "parsing recipient address")
+	}
+
+	var sub, meta map[string]interface{}
+	var ok bool
+	if sub, ok = r.SubstitutionData.(map[string]interface{}); !ok && r.SubstitutionData != nil {
+		return "", errors.Errorf("unexpected substitution data type for recipient %s", addr.Email)
+	}
+	if meta, ok = r.Metadata.(map[string]interface{}); !ok && r.Metadata != nil {
+		return "", errors.Errorf("unexpected metadata type for recipient %s", addr.Email)
+	}
+
+	for idx, token := range tokens {
+		switch token.Type {
+		case StaticToken:
+			chunks[idx] = token.Text
+
+		case MacroToken:
+			key := strings.TrimSpace(strings.Trim(token.Text, "{}"))
+			for _, subst := range []map[string]interface{}{sub, meta} {
+				if ival, ok := subst[key]; ok {
+					switch val := ival.(type) {
+					case string:
+						chunks[idx] = val
+					default:
+						chunks[idx] = token.Text
+					}
+					break
+				}
+			}
+		}
+	}
+
+	if len(chunks) == 1 {
+		return chunks[0], nil
+	}
+	return strings.Join(chunks, ""), nil
+}
+
+// ApplyMacros runs all Macros registered with the Client against the provided string, returning the result.
+// If a Recipient is provided, substitution is performed on the macro parameter before the macro runs.
+// Any placeholders not handled by a macro are left intact.
+func (c *Client) ApplyMacros(in string, r *Recipient) (string, error) {
+	if c.macros == nil {
+		// if no macros are defined, this is a no-op
+		return in, nil
+	}
+
+	tokens, err := Tokenize(in)
+	if err != nil {
+		return "", err
+	}
+	chunks := make([]string, len(tokens))
+
+	for idx, token := range tokens {
+		switch token.Type {
+		case StaticToken:
+			chunks[idx] = token.Text
+
+		case MacroToken:
+			body := strings.TrimSpace(strings.Trim(token.Text, "{}"))
+			// split off macro name
+			atoms := strings.SplitN(body, " ", 2)
+			if m, ok := c.macros[atoms[0]]; ok {
+				var params string
+				if len(atoms) == 2 {
+					params = atoms[1]
+				} else {
+					params = ""
+				}
+				if r != nil {
+					params, err = r.Apply(params)
+					if err != nil {
+						return "", err
+					}
+				}
+				chunks[idx] = m.Func(params)
+			} else {
+				return "", errors.Errorf("no such macro %q", atoms[0])
+			}
+
+		default:
+			return "", errors.Errorf("unsupported token type %q", token.Type)
+		}
+	}
+
+	if len(chunks) == 1 {
+		return chunks[0], nil
+	}
+	return strings.Join(chunks, ""), nil
+}
+
+func Tokenize(str string) (out []ContentToken, err error) {
+	strlen := len(str)
+	for {
+		open := strings.Index(str, "{{")
+		if open >= 0 && open < strlen {
+			if open > 0 {
+				// we have a macro, make a token with the static text leading up to it
+				out = append(out, ContentToken{Text: str[:open]})
+				str = str[open:]
+				strlen -= open
+			} else {
+				// Do nothing if macro starts at index 0,
+				// otherwise we end up with blank StaticTokens
+			}
+		} else {
+			break
+		}
+
+		// advance to the end of the macro
+		curlies := 0
+		var last int
+		for last = 0; last < strlen; last++ {
+			switch str[last] {
+			case '{':
+				curlies++
+			case '}':
+				curlies--
+			}
+			if curlies == 0 {
+				last++
+				break
+			}
+		}
+
+		if curlies != 0 {
+			return nil, errors.Errorf("mismatched curly braces near %s", str)
+		}
+
+		out = append(out, ContentToken{
+			Type: MacroToken,
+			Text: str[:last],
+		})
+
+		str = str[last:]
+		strlen -= last
+	}
+	if strlen > 0 {
+		out = append(out, ContentToken{Text: str})
+	}
+	return out, nil
+}

--- a/macros_test.go
+++ b/macros_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+var upperMacro = sp.Macro{Name: "ext_upper", Func: strings.ToUpper}
+var lowerMacro = sp.Macro{Name: "ext_lower", Func: strings.ToLower}
+
 func TestRegisterMacro(t *testing.T) {
 	tests := []struct {
 		macro *sp.Macro
@@ -42,10 +45,9 @@ func TestApplyMacros(t *testing.T) {
 		out      string
 		err      error
 	}{
-		{[]sp.Macro{
-			sp.Macro{Name: "ext_foo", Func: strings.ToUpper},
-			sp.Macro{Name: "ext_bar", Func: strings.ToLower},
-		}, nil, "{{ ext_foo bar }}{{ ext_bar FOO }}", "BARfoo", nil},
+		{[]sp.Macro{upperMacro}, nil, "{{ext_upper}}", "", nil},
+		{[]sp.Macro{upperMacro, lowerMacro},
+			nil, "{{ ext_upper bar }}{{ ext_lower FOO }}", "BARfoo", nil},
 
 		{
 			[]sp.Macro{

--- a/macros_test.go
+++ b/macros_test.go
@@ -10,6 +10,9 @@ import (
 
 var upperMacro = sp.Macro{Name: "ext_upper", Func: strings.ToUpper}
 var lowerMacro = sp.Macro{Name: "ext_lower", Func: strings.ToLower}
+var noopMacro = sp.Macro{Name: "ext_noop", Func: NoopMacro}
+
+func NoopMacro(in string) string { return in }
 
 func TestRegisterMacro(t *testing.T) {
 	tests := []struct {
@@ -122,6 +125,14 @@ func TestApplyMacros(t *testing.T) {
 				Metadata:         map[string]interface{}{"abc": 42},
 				SubstitutionData: map[string]interface{}{"ghi": 42},
 			}, "{{ ext_upper {{abc}} }}{{ ext_lower ({{ghi}}) }}", "{{ABC}}({{ghi}})", nil},
+
+		// substitution data overrides metadata
+		{[]sp.Macro{noopMacro},
+			&sp.Recipient{
+				Address:          "test@example.com",
+				Metadata:         map[string]interface{}{"abc": "def", "ghi": "jkl"},
+				SubstitutionData: map[string]interface{}{"abc": "DEF"},
+			}, "{{ ext_noop {{abc}} }}{{ ext_noop ({{ghi}}) }}", "DEF(jkl)", nil},
 
 		// recipient macros nested inside client macros
 		{[]sp.Macro{upperMacro, lowerMacro},

--- a/macros_test.go
+++ b/macros_test.go
@@ -1,0 +1,78 @@
+package gosparkpost_test
+
+import (
+	"strings"
+	"testing"
+
+	sp "github.com/SparkPost/gosparkpost"
+	"github.com/pkg/errors"
+)
+
+func TestRegisterMacro(t *testing.T) {
+	tests := []struct {
+		macro *sp.Macro
+		err   error
+	}{
+		{nil, errors.New(`can't add nil Macro`)},
+		{&sp.Macro{Name: ""}, errors.New(`Macro names must only contain \w characters`)},
+		{&sp.Macro{Name: "b:ar"}, errors.New(`Macro names must only contain \w characters`)},
+		{&sp.Macro{Name: "bar"}, errors.New(`Macro must have non-nil Func field`)},
+		{&sp.Macro{Name: "bar", Func: strings.ToUpper}, nil},
+	}
+
+	for idx, test := range tests {
+		testSetup(t)
+		defer testTeardown()
+
+		err := testClient.RegisterMacro(test.macro)
+		if err == nil && test.err != nil || err != nil && test.err == nil {
+			t.Errorf("RegisterMacro[%d] => err %q want %q", idx, err, test.err)
+		} else if err != nil && err.Error() != test.err.Error() {
+			t.Errorf("TemplateCreate[%d] => err %q want %q", idx, err, test.err)
+		}
+	}
+	testClient = nil
+}
+
+func TestApplyMacros(t *testing.T) {
+	tests := []struct {
+		macros   []sp.Macro
+		recip    *sp.Recipient
+		template string
+		out      string
+		err      error
+	}{
+		{[]sp.Macro{
+			sp.Macro{Name: "ext_foo", Func: strings.ToUpper},
+			sp.Macro{Name: "ext_bar", Func: strings.ToLower},
+		}, nil, "{{ ext_foo bar }}{{ ext_bar FOO }}", "BARfoo", nil},
+
+		{
+			[]sp.Macro{
+				sp.Macro{Name: "ext_foo", Func: strings.ToUpper},
+				sp.Macro{Name: "ext_bar", Func: strings.ToLower},
+			}, &sp.Recipient{Address: "test@example.com", Metadata: map[string]interface{}{"abc": "def", "ghi": "JKL"}},
+			"{{ ext_foo {{abc}} }}{{ ext_bar {{ghi}} }}", "DEFjkl", nil},
+	}
+
+	for idx, test := range tests {
+		testSetup(t)
+		defer testTeardown()
+
+		for _, m := range test.macros {
+			err := testClient.RegisterMacro(&m)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		out, err := testClient.ApplyMacros(test.template, test.recip)
+		if err == nil && test.err != nil || err != nil && test.err == nil {
+			t.Errorf("ApplyMacros[%d] => err %q want %q", idx, err, test.err)
+		} else if err != nil && err.Error() != test.err.Error() {
+			t.Errorf("ApplyMacros[%d] => err %q want %q", idx, err, test.err)
+		} else if out != test.out {
+			t.Errorf("ApplyMacros[%d] => got/want:\n%s\n%s\n", idx, out, test.out)
+		}
+	}
+}

--- a/macros_test.go
+++ b/macros_test.go
@@ -3,7 +3,6 @@ package gosparkpost_test
 import (
 	"crypto/tls"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -211,7 +210,7 @@ func InvoiceMacro(client *http.Client) func(string) string {
 			return err.Error()
 		}
 		body, err := ioutil.ReadAll(res.Body)
-		if err != nil && err != io.EOF {
+		if err != nil {
 			return err.Error()
 		}
 		return string(body)

--- a/macros_test.go
+++ b/macros_test.go
@@ -181,6 +181,7 @@ func TestApplyMacros(t *testing.T) {
 
 func TestInvoice(t *testing.T) {
 	s := httptest.NewTLSServer(http.HandlerFunc(testInvoice))
+	defer s.Close()
 	tx := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
 	client := &http.Client{Transport: tx}
 	spClient := &sp.Client{}

--- a/macros_test.go
+++ b/macros_test.go
@@ -37,6 +37,33 @@ func TestRegisterMacro(t *testing.T) {
 	testClient = nil
 }
 
+func TestRecipientApply(t *testing.T) {
+	tests := []struct {
+		r   *sp.Recipient
+		in  string
+		out string
+		err error
+	}{
+		// nil recipient returns input string unchanged
+		{nil, "in", "in", nil},
+		// tokenize catches template error
+		// this only happens in this function when used standalone
+		// when using ApplyMacros, all tokenize errors are caught at that level
+		{&sp.Recipient{}, "{{{ foo }}", "", errors.New(`mismatched curly braces near "{{{ foo }}"`)},
+	}
+
+	for idx, test := range tests {
+		out, err := test.r.Apply(test.in)
+		if err == nil && test.err != nil || err != nil && test.err == nil {
+			t.Errorf("Apply[%d] => err %q want %q", idx, err, test.err)
+		} else if err != nil && err.Error() != test.err.Error() {
+			t.Errorf("Apply[%d] => err %q want %q", idx, err, test.err)
+		} else if out != test.out {
+			t.Errorf("Apply[%d] => got/want:\n%s\n%s\n", idx, out, test.out)
+		}
+	}
+}
+
 func TestApplyMacros(t *testing.T) {
 	tests := []struct {
 		macros   []sp.Macro
@@ -45,16 +72,64 @@ func TestApplyMacros(t *testing.T) {
 		out      string
 		err      error
 	}{
-		{[]sp.Macro{upperMacro}, nil, "{{ext_upper}}", "", nil},
-		{[]sp.Macro{upperMacro, lowerMacro},
-			nil, "{{ ext_upper bar }}{{ ext_lower FOO }}", "BARfoo", nil},
+		// not enough closing curlies
+		{[]sp.Macro{upperMacro}, nil, "{{{ext_upper}}", "", errors.New(`mismatched curly braces near "{{{ext_upper}}"`)},
+		// balanced triple curlies
+		{[]sp.Macro{upperMacro}, nil, "{{{ext_upper}}}", "", nil},
+		// extra trailing curlies
+		{[]sp.Macro{upperMacro}, nil, "{{ext_upper}}}", "}", nil},
 
-		{
-			[]sp.Macro{
-				sp.Macro{Name: "ext_foo", Func: strings.ToUpper},
-				sp.Macro{Name: "ext_bar", Func: strings.ToLower},
-			}, &sp.Recipient{Address: "test@example.com", Metadata: map[string]interface{}{"abc": "def", "ghi": "JKL"}},
-			"{{ ext_foo {{abc}} }}{{ ext_bar {{ghi}} }}", "DEFjkl", nil},
+		// no macros defined, pass through
+		{[]sp.Macro{}, nil, "{{ext_upper}}", "{{ext_upper}}", nil},
+		{[]sp.Macro{}, nil, "{{ext_upper foo}}", "{{ext_upper foo}}", nil},
+		// macros defined, pass through ones that don't match
+		{[]sp.Macro{lowerMacro}, nil, "{{ext_upper}}", "{{ext_upper}}", nil},
+
+		// multiple macros, preserving space outside blocks
+		{[]sp.Macro{upperMacro, lowerMacro},
+			nil, " {{ ext_upper bar }} {{ ext_lower FOO }} ", " BAR foo ", nil},
+
+		// invalid recipient address
+		{[]sp.Macro{upperMacro},
+			&sp.Recipient{
+				Address: 42,
+			}, "{{ ext_upper {{abc}} }}", "", errors.New("parsing recipient address: unsupported Recipient.Address value type [int]")},
+
+		// bad recipient metadata format
+		{[]sp.Macro{upperMacro},
+			&sp.Recipient{
+				Address:  "test@example.com",
+				Metadata: 42,
+			}, "{{ ext_upper }}", "", errors.New("unexpected metadata type [int] for recipient test@example.com")},
+
+		// bad recipient substitution data format
+		{[]sp.Macro{upperMacro},
+			&sp.Recipient{
+				Address:          "test@example.com",
+				SubstitutionData: 42,
+			}, "{{ ext_upper }}", "", errors.New("unexpected substitution data type [int] for recipient test@example.com")},
+
+		// non-string meta/sub data
+		{[]sp.Macro{upperMacro, lowerMacro},
+			&sp.Recipient{
+				Address:          "test@example.com",
+				Metadata:         map[string]interface{}{"abc": 42},
+				SubstitutionData: map[string]interface{}{"ghi": 42},
+			}, "{{ ext_upper {{abc}} }}{{ ext_lower ({{ghi}}) }}", "{{ABC}}({{ghi}})", nil},
+
+		// recipient macros nested inside client macros
+		{[]sp.Macro{upperMacro, lowerMacro},
+			&sp.Recipient{
+				Address:  "test@example.com",
+				Metadata: map[string]interface{}{"abc": "def", "ghi": "JKL"},
+			}, "{{ ext_upper {{abc}} }}{{ ext_lower ({{ghi}}) }}", "DEF(jkl)", nil},
+
+		// not enough trailing curlies for nested macros
+		{[]sp.Macro{upperMacro},
+			&sp.Recipient{
+				Address:  "test@example.com",
+				Metadata: map[string]interface{}{"abc": "def", "ghi": "JKL"},
+			}, "{{ ext_upper {{{abc}} }}", "", errors.New(`mismatched curly braces near "{{ ext_upper {{{abc}} }}"`)},
 	}
 
 	for idx, test := range tests {
@@ -76,5 +151,7 @@ func TestApplyMacros(t *testing.T) {
 		} else if out != test.out {
 			t.Errorf("ApplyMacros[%d] => got/want:\n%s\n%s\n", idx, out, test.out)
 		}
+		// discard client (where macros live) so next test gets a fresh start
+		testClient = nil
 	}
 }

--- a/macros_test.go
+++ b/macros_test.go
@@ -46,10 +46,16 @@ func TestRecipientApply(t *testing.T) {
 	}{
 		// nil recipient returns input string unchanged
 		{nil, "in", "in", nil},
+
 		// tokenize catches template error
 		// this only happens in this function when used standalone
 		// when using ApplyMacros, all tokenize errors are caught at that level
 		{&sp.Recipient{}, "{{{ foo }}", "", errors.New(`mismatched curly braces near "{{{ foo }}"`)},
+
+		{&sp.Recipient{
+			Address:  "test@example.com",
+			Metadata: map[string]interface{}{"foo": "bar"},
+		}, "{{ foo }}", "bar", nil},
 	}
 
 	for idx, test := range tests {


### PR DESCRIPTION
Default behavior is unchanged. Here's an overview of new types and functions:

    type Macro struct {
        Name string
        Func func(string) string
    }

    type ContentToken struct {
        Type TokenType // int, StaticToken=0 or MacroToken=1
        Text string
    }

    // Enable your Macros here
    func (c *Client) RegisterMacro(m *Macro) error

    // You probably won't need this one, but it's there just in case.
    // Used by Client.ApplyMacros and Recipient.Apply, below
    func Tokenize(str string) (out []ContentToken, err error)

    // Process registered Macros with optional Recipient
    func (c *Client) ApplyMacros(in string, r *Recipient) (string, error)

    // You probably won't need this one either.
    // Called automatically by ApplyMacros if Recipient != nil
    func (r *Recipient) Apply(in string) (string, error)