### PR TITLE
Add EventID and InitialOpen event

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -53,6 +53,8 @@ func EventForName(eventType string) Event {
 		return &ListUnsubscribe{}
 	case "link_unsubscribe":
 		return &LinkUnsubscribe{}
+	case "initial_open":
+		return &InitialOpen{}
 	case "open":
 		return &Open{}
 	case "out_of_band":

--- a/events/generation.go
+++ b/events/generation.go
@@ -9,6 +9,7 @@ type GenerationFailure struct {
 	CampaignID       string      `json:"campaign_id"`
 	CustomerID       string      `json:"customer_id"`
 	ErrorCode        string      `json:"error_code"`
+	EventID          string      `json:"event_id"`
 	Metadata         interface{} `json:"rcpt_meta"`
 	SubstitutionData interface{} `json:"rcpt_subs"`
 	Tags             []string    `json:"rcpt_tags"`

--- a/events/message.go
+++ b/events/message.go
@@ -91,6 +91,7 @@ type Bounce struct {
 	DeliveryMethod  string            `json:"delv_method"`
 	DeviceToken     string            `json:"device_token"`
 	ErrorCode       string            `json:"error_code"`
+	EventID         string            `json:"event_id"`
 	IPAddress       string            `json:"ip_address"`
 	MessageID       string            `json:"message_id"`
 	MessageFrom     string            `json:"msg_from"`
@@ -137,6 +138,7 @@ type OutOfBand struct {
 	DeliveryMethod  string    `json:"delv_method"`
 	DeviceToken     string    `json:"device_token"`
 	ErrorCode       string    `json:"error_code"`
+	EventID         string    `json:"event_id"`
 	MessageID       string    `json:"message_id"`
 	MessageFrom     string    `json:"msg_from"`
 	Recipient       string    `json:"rcpt_to"`
@@ -171,6 +173,7 @@ type SpamComplaint struct {
 	CampaignID      string      `json:"campaign_id"`
 	CustomerID      string      `json:"customer_id"`
 	DeliveryMethod  string      `json:"delv_method"`
+	EventID         string      `json:"event_id"`
 	FeedbackType    string      `json:"fbtype"`
 	FriendlyFrom    string      `json:"friendly_from"`
 	MessageID       string      `json:"message_id"`
@@ -199,6 +202,7 @@ type PolicyRejection struct {
 	CampaignID      string      `json:"campaign_id"`
 	CustomerID      string      `json:"customer_id"`
 	ErrorCode       string      `json:"error_code"`
+	EventID         string      `json:"event_id"`
 	MessageID       string      `json:"message_id"`
 	MessageFrom     string      `json:"msg_from"`
 	Metadata        interface{} `json:"rcpt_meta"`
@@ -233,6 +237,7 @@ type Delay struct {
 	DeliveryMethod  string      `json:"delv_method"`
 	DeviceToken     string      `json:"device_token"`
 	ErrorCode       string      `json:"error_code"`
+	EventID         string      `json:"event_id"`
 	IPAddress       string      `json:"ip_address"`
 	MessageID       string      `json:"message_id"`
 	MessageFrom     string      `json:"msg_from"`

--- a/events/relay.go
+++ b/events/relay.go
@@ -7,6 +7,7 @@ type RelayInjection struct {
 	Binding         string    `json:"binding"`
 	BindingGroup    string    `json:"binding_group"`
 	CustomerID      string    `json:"customer_id"`
+	EventID         string    `json:"event_id"`
 	MessageFrom     string    `json:"msg_from"`
 	MessageSize     string    `json:"msg_size"`
 	Pathway         string    `json:"pathway"`
@@ -28,6 +29,7 @@ type RelayRejection struct {
 	EventCommon
 	CustomerID      string    `json:"customer_id"`
 	ErrorCode       string    `json:"error_code"`
+	EventID         string    `json:"event_id"`
 	MessageFrom     string    `json:"msg_from"`
 	Pathway         string    `json:"pathway"`
 	PathwayGroup    string    `json:"pathway_group"`
@@ -52,6 +54,7 @@ type RelayDelivery struct {
 	BindingGroup    string    `json:"binding_group"`
 	CustomerID      string    `json:"customer_id"`
 	DeliveryMethod  string    `json:"delv_method"`
+	EventID         string    `json:"event_id"`
 	MessageFrom     string    `json:"msg_from"`
 	Pathway         string    `json:"pathway"`
 	PathwayGroup    string    `json:"pathway_group"`
@@ -76,6 +79,7 @@ type RelayTempfail struct {
 	CustomerID      string    `json:"customer_id"`
 	DeliveryMethod  string    `json:"delv_method"`
 	ErrorCode       string    `json:"error_code"`
+	EventID         string    `json:"event_id"`
 	MessageFrom     string    `json:"msg_from"`
 	Retries         string    `json:"num_retries"`
 	QueueTime       string    `json:"queue_time"`

--- a/events/track.go
+++ b/events/track.go
@@ -55,3 +55,14 @@ func (o *Open) String() string {
 	return fmt.Sprintf("%s O %s %s",
 		o.Timestamp, o.TransmissionID, o.Recipient)
 }
+
+type InitialOpen struct {
+	EventCommon
+	Open
+}
+
+// String returns a brief summary of an InitialOpen event
+func (i *InitialOpen) String() string {
+	return fmt.Sprintf("%s O %s %s",
+		i.Timestamp, i.TransmissionID, i.Recipient)
+}

--- a/events/track.go
+++ b/events/track.go
@@ -7,6 +7,7 @@ type Click struct {
 	CampaignID      string      `json:"campaign_id"`
 	CustomerID      string      `json:"customer_id"`
 	DeliveryMethod  string      `json:"delv_method"`
+	EventID         string      `json:"event_id"`
 	GeoIP           *GeoIP      `json:"geo_ip"`
 	IPAddress       string      `json:"ip_address"`
 	MessageID       string      `json:"message_id"`
@@ -34,6 +35,7 @@ type Open struct {
 	CampaignID      string      `json:"campaign_id"`
 	CustomerID      string      `json:"customer_id"`
 	DeliveryMethod  string      `json:"delv_method"`
+	EventID         string      `json:"event_id"`
 	GeoIP           *GeoIP      `json:"geo_ip"`
 	IPAddress       string      `json:"ip_address"`
 	MessageID       string      `json:"message_id"`

--- a/events/unsubscribe.go
+++ b/events/unsubscribe.go
@@ -6,6 +6,7 @@ type ListUnsubscribe struct {
 	EventCommon
 	CampaignID      string      `json:"campaign_id"`
 	CustomerID      string      `json:"customer_id"`
+	EventID         string      `json:"event_id"`
 	MessageFrom     string      `json:"mailfrom"`
 	MessageID       string      `json:"message_id"`
 	Metadata        interface{} `json:"rcpt_meta"`

--- a/test/event-docs.json
+++ b/test/event-docs.json
@@ -1227,6 +1227,103 @@
           },
           "description": "Recipient opened a message in a mail client, thus rendering a tracking pixel.",
           "display_name": "Open"
+        },
+        "initial_open": {
+          "event": {
+            "type": {
+              "description": "Type of event this record describes",
+              "sampleValue": "initial_open"
+            },
+            "campaign_id": {
+              "description": "Campaign of which this message was a part",
+              "sampleValue": "Example Campaign Name"
+            },
+            "customer_id": {
+              "description": "SparkPost-customer identifier through which this message was sent",
+              "sampleValue": "1"
+            },
+            "delv_method": {
+              "description": "Protocol by which SparkPost delivered this message",
+              "sampleValue": "esmtp"
+            },
+            "event_id": {
+              "description": "Unique event identifier",
+              "sampleValue": "92356927693813856"
+            },
+            "ip_address": {
+              "description": "IP address of the host to which SparkPost delivered this message; in engagement events, the IP address of the host where the HTTP request originated",
+              "sampleValue": "127.0.0.1"
+            },
+            "message_id": {
+              "description": "SparkPost-cluster-wide unique identifier for this message",
+              "sampleValue": "000443ee14578172be22"
+            },
+            "rcpt_meta": {
+              "description": "Metadata describing the message recipient",
+              "sampleValue": {
+                "customKey": "customValue"
+              }
+            },
+            "rcpt_tags": {
+              "description": "Tags applied to the message which generated this event",
+              "sampleValue": [
+                "male",
+                "US"
+              ]
+            },
+            "rcpt_to": {
+              "description": "Lowercase version of recipient address used on this message's SMTP envelope",
+              "sampleValue": "recipient@example.com"
+            },
+            "raw_rcpt_to": {
+              "description": "Actual recipient address used on this message's SMTP envelope",
+              "sampleValue": "Recipient@example.com"
+            },
+            "rcpt_type": {
+              "description": "Indicates that a recipient address appeared in the Cc or Bcc header or the archive JSON array",
+              "sampleValue": "cc"
+            },
+            "subaccount_id": {
+              "description": "Unique subaccount identifier.",
+              "sampleValue": "101"
+            },
+            "template_id": {
+              "description": "Slug of the template used to construct this message",
+              "sampleValue": "templ-1234"
+            },
+            "template_version": {
+              "description": "Version of the template used to construct this message",
+              "sampleValue": "1"
+            },
+            "timestamp": {
+              "description": "Event date and time, in Unix timestamp format (integer seconds since 00:00:00 GMT 1970-01-01)",
+              "sampleValue": "1454442600"
+            },
+            "transmission_id": {
+              "description": "Transmission which originated this message",
+              "sampleValue": "65832150921904138"
+            },
+            "user_agent": {
+              "description": "Value of the browser's User-Agent header",
+              "sampleValue": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 Safari/537.36"
+            },
+            "geo_ip": {
+              "description": "Geographic location based on the IP address, including latitude, longitude, city, country, and region",
+              "sampleValue": {
+                "country": "US",
+                "region": "MD",
+                "city": "Columbia",
+                "latitude": 39.1749,
+                "longitude": -76.8375
+              }
+            },
+            "sending_ip": {
+              "description": "IP address through which this message was sent",
+              "sampleValue": "127.0.0.1"
+            }
+          },
+          "description": "Recipient opened a message in a mail client, thus rendering a tracking pixel at the top of the message.",
+          "display_name": "Initial Open"
         }
       },
       "description": "Engagement events describe the behavior of a recipient with respect to the message sent.",


### PR DESCRIPTION
Background
------------
This pull requests adds:
*  `InitialOpen` event in `track.go`
* `EventID` attributes in all the rests of the Webhooks events.

References
-----------
* [Webhooks Events References Guide](https://www.sparkpost.com/docs/tech-resources/webhook-event-reference/#event-types)
