### PR TITLE
feat(transmissions): add perform substitutions option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
-  - 1.7
+  - "1.10"
 before_install:
   go get github.com/mattn/goveralls
 script:

--- a/cmd/mimedump/mimedump.go
+++ b/cmd/mimedump/mimedump.go
@@ -5,11 +5,10 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"net/mail"
 	"os"
 	"strings"
 
-	mime "github.com/jhillyerd/go.enmime"
+	mime "github.com/jhillyerd/enmime"
 )
 
 func main() {
@@ -26,23 +25,18 @@ func main() {
 		log.Fatal(err)
 	}
 
-	msg, err := mail.ReadMessage(fh)
+	e, err := mime.ReadEnvelope(fh)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	m, err := mime.ParseMIMEBody(msg)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fmt.Fprintf(os.Stderr, "HTML=%d Text=%d\n", len(m.HTML), len(m.Text))
-	if len(m.HTML) <= 0 {
+	fmt.Fprintf(os.Stderr, "HTML=%d Text=%d\n", len(e.HTML), len(e.Text))
+	if len(e.HTML) <= 0 {
 		log.Fatalf("No HTML part found in %s\n", *filename)
 	}
 
 	w := bufio.NewWriter(os.Stdout)
-	n, err := w.WriteString(m.HTML)
+	n, err := w.WriteString(e.HTML)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/recipient_lists_test.go
+++ b/recipient_lists_test.go
@@ -167,7 +167,7 @@ func TestRecipientLists(t *testing.T) {
 		} else if err != nil && err.Error() != test.err.Error() {
 			t.Errorf("RecipientLists[%d] => err %q want %q", idx, err, test.err)
 		} else if test.out != nil && !reflect.DeepEqual(lists, test.out) {
-			t.Errorf("RecipientLists[%d] => got/want:\n%q\n%q", idx, lists, test.out)
+			t.Errorf("RecipientLists[%d] => got/want:\n%#v\n%#v", idx, lists, test.out)
 		}
 	}
 }

--- a/suppression_list_test.go
+++ b/suppression_list_test.go
@@ -589,7 +589,7 @@ func mockRestRequestResponseBuilder(t *testing.T, method string, status int, pat
 			}
 
 			if !ok {
-				testFailVerbose(t, nil, "Request did not match expected. \nExpected: \n%s\n\nActual:\n%s\n\n", err)
+				testFailVerbose(t, nil, "Request did not match expected. \nExpected: \n%s\n\nActual:\n%s\n\n", expectedBody, string(body[:]))
 			}
 		}
 

--- a/templates_test.go
+++ b/templates_test.go
@@ -253,10 +253,10 @@ func TestTemplateUpdate(t *testing.T) {
 		status int
 		json   string
 	}{
-		{nil, false, errors.New("Update called with nil Template"), 0, ""},
-		{&sp.Template{ID: ""}, false, errors.New("Update called with blank id"), 0, ""},
-		{&sp.Template{ID: "id", Content: sp.Content{}}, false, errors.New("Template requires a non-empty Content.Subject"), 0, ""},
-		{&sp.Template{ID: "id", Content: sp.Content{Subject: "s", HTML: "h", From: "f"}}, false, errors.New("parsing api response: unexpected end of JSON input"), 0, `{ "errors": [ { "message": "truncated json" }`},
+		{nil, false, errors.New("Update called with nil Template"), 500, ""},
+		{&sp.Template{ID: ""}, false, errors.New("Update called with blank id"), 500, ""},
+		{&sp.Template{ID: "id", Content: sp.Content{}}, false, errors.New("Template requires a non-empty Content.Subject"), 500, ""},
+		{&sp.Template{ID: "id", Content: sp.Content{Subject: "s", HTML: "h", From: "f"}}, false, errors.New("parsing api response: unexpected end of JSON input"), 500, `{ "errors": [ { "message": "truncated json" }`},
 
 		{&sp.Template{ID: "id", Content: sp.Content{Subject: "s{{", HTML: "h", From: "f"}}, false,
 			sp.SPErrors([]sp.SPError{{
@@ -293,8 +293,8 @@ func TestTemplates(t *testing.T) {
 		status int
 		json   string
 	}{
-		{errors.New("parsing api response: unexpected end of JSON input"), 0, `{ "errors": [ { "message": "truncated json" }`},
-		{errors.New("[{\"message\":\"truncated json\",\"code\":\"\",\"description\":\"\"}]"), 0, `{ "errors": [ { "message": "truncated json" } ] }`},
+		{errors.New("parsing api response: unexpected end of JSON input"), 500, `{ "errors": [ { "message": "truncated json" }`},
+		{errors.New("[{\"message\":\"truncated json\",\"code\":\"\",\"description\":\"\"}]"), 500, `{ "errors": [ { "message": "truncated json" } ] }`},
 		{nil, 200, `{ "results": [ { "description": "A test message from SparkPost.com", "id": "my-first-email", "last_update_time": "2006-01-02T15:04:05+00:00", "name": "My First Email", "published": false } ] }`},
 	} {
 		testSetup(t)

--- a/transmissions.go
+++ b/transmissions.go
@@ -47,12 +47,13 @@ func (r *RFC3339) MarshalJSON() ([]byte, error) {
 type TxOptions struct {
 	TmplOptions
 
-	StartTime       *RFC3339 `json:"start_time,omitempty"`
-	Transactional   *bool    `json:"transactional,omitempty"`
-	Sandbox         *bool    `json:"sandbox,omitempty"`
-	SkipSuppression *bool    `json:"skip_suppression,omitempty"`
-	IPPool          string   `json:"ip_pool,omitempty"`
-	InlineCSS       *bool    `json:"inline_css,omitempty"`
+	StartTime            *RFC3339 `json:"start_time,omitempty"`
+	Transactional        *bool    `json:"transactional,omitempty"`
+	Sandbox              *bool    `json:"sandbox,omitempty"`
+	SkipSuppression      *bool    `json:"skip_suppression,omitempty"`
+	IPPool               string   `json:"ip_pool,omitempty"`
+	InlineCSS            *bool    `json:"inline_css,omitempty"`
+	PerformSubstitutions *bool    `json:"perform_substitutions,omitempty"`
 }
 
 // ParseRecipients asserts that Transmission.Recipients is valid.

--- a/transmissions_test.go
+++ b/transmissions_test.go
@@ -166,28 +166,39 @@ func TestTransmissions_ByID_Success(t *testing.T) {
 func TestTransmissionOptions(t *testing.T) {
 	var jsonb []byte
 	var err error
-	var opt bool
 
-	tx := &sp.Transmission{}
-	to := &sp.TxOptions{InlineCSS: &opt}
-	tx.Options = to
-
-	jsonb, err = json.Marshal(tx)
-	if err != nil {
-		t.Fatal(err)
+	tableTests := []struct {
+		options  *sp.TxOptions
+		wantJson []byte
+	}{
+		{
+			&sp.TxOptions{InlineCSS: new(bool)},
+			[]byte(`"options":{"inline_css":false}`),
+		},
+		{
+			&sp.TxOptions{},
+			[]byte(`"options":{}`),
+		},
+		{
+			&sp.TxOptions{InlineCSS: new(bool), PerformSubstitutions: new(bool)},
+			[]byte(`"options":{"inline_css":false,"perform_substitutions":false}`),
+		},
 	}
 
-	if !bytes.Contains(jsonb, []byte(`"options":{"inline_css":false}`)) {
-		t.Fatalf("expected inline_css option to be false:\n%s", string(jsonb))
-	}
+	for _, tt := range tableTests {
+		tx := &sp.Transmission{}
+		to := tt.options
+		tx.Options = to
 
-	opt = true
-	jsonb, err = json.Marshal(tx)
-	if err != nil {
-		t.Fatal(err)
-	}
+		jsonb, err = json.Marshal(tx)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if !bytes.Contains(jsonb, []byte(`"options":{"inline_css":true}`)) {
-		t.Fatalf("expected inline_css option to be true:\n%s", string(jsonb))
+		if !bytes.Contains(jsonb, tt.wantJson) {
+			t.Error("could not match options")
+			t.Errorf("Got  :\n%s", tt.wantJson)
+			t.Fatalf("Want :\n%s", string(jsonb))
+		}
 	}
 }


### PR DESCRIPTION
As supported from sparkpost API a perform_substitutions is added, In order to do not add BC for the client omitempty is used too.