### PR TITLE
add support for template option 'initial_open'

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -64,3 +64,10 @@ Here's the output of the example linked above, which generates a message with 2 
       }
     }
 
+### Transmission Options
+
+Transmission options can be used to control various settings on the transmission you're building, and can be used to override
+some account-level settings (such as open tracking).
+
+[Options example](options/options.go)
+

--- a/examples/options/options.go
+++ b/examples/options/options.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	sp "github.com/SparkPost/gosparkpost"
+	"os"
+)
+
+func main() {
+	content := sp.Content{
+		From:    "test@example.com",
+		Subject: "transmission options example message",
+		Text:    "This is a transmissions options example",
+	}
+
+	initialOpenTracking := false
+	openTracking := true
+	clickTracking := true
+	options := sp.TmplOptions{
+		InitialOpenTracking: &initialOpenTracking,
+		OpenTracking: &openTracking,
+		ClickTracking: &clickTracking,
+	}
+
+	txOptions := &sp.TxOptions{
+		TmplOptions: options,
+		IPPool: "my-ip-pool",
+	}
+
+	tx := &sp.Transmission{
+		Recipients: []sp.Recipient{{Address: "optionstest@test.com.sink.sparkpostmail.com"}},
+	}
+	tx.Content = content
+	tx.Options = txOptions
+
+	jsonBytes, err := json.Marshal(tx)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Fprintln(os.Stdout, string(jsonBytes))
+
+}
+

--- a/templates.go
+++ b/templates.go
@@ -61,9 +61,10 @@ type From struct {
 // TmplOptions specifies settings to apply to this Template.
 // These settings may be overridden in the Transmission API call.
 type TmplOptions struct {
-	OpenTracking  *bool `json:"open_tracking,omitempty"`
-	ClickTracking *bool `json:"click_tracking,omitempty"`
-	Transactional *bool `json:"transactional,omitempty"`
+	InitialOpenTracking *bool `json:"initial_open,omitempty"`
+	OpenTracking        *bool `json:"open_tracking,omitempty"`
+	ClickTracking       *bool `json:"click_tracking,omitempty"`
+	Transactional       *bool `json:"transactional,omitempty"`
 }
 
 // PreviewOptions contains the required subsitution_data object to

--- a/transmissions_test.go
+++ b/transmissions_test.go
@@ -180,6 +180,10 @@ func TestTransmissionOptions(t *testing.T) {
 			[]byte(`"options":{}`),
 		},
 		{
+			&sp.TxOptions{TmplOptions: sp.TmplOptions{InitialOpenTracking: new(bool)}},
+			[]byte(`"options":{"initial_open":false}`),
+		},
+		{
 			&sp.TxOptions{InlineCSS: new(bool), PerformSubstitutions: new(bool)},
 			[]byte(`"options":{"inline_css":false,"perform_substitutions":false}`),
 		},


### PR DESCRIPTION
Added initial_open to transmission template options so that we can set it on a per-transmission basis.
Also added an example for setting transmission options and added to the existing template options test.