### PR TITLE
simplify ECLog switch statement

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -163,23 +163,8 @@ func parseRawJSONEventsFromSamples(data []byte) ([]json.RawMessage, error) {
 }
 
 func ECLog(e Event) string {
-	// XXX: this feels like the wrong way; can't figure out the right way
-	switch e.(type) {
-	case *Bounce:
-		b := e.(*Bounce)
-		return b.ECLog()
-	case *Delay:
-		d := e.(*Delay)
-		return d.ECLog()
-	case *Delivery:
-		d := e.(*Delivery)
-		return d.ECLog()
-	case *Injection:
-		i := e.(*Injection)
-		return i.ECLog()
-	case *OutOfBand:
-		o := e.(*OutOfBand)
-		return o.ECLog()
+	if logger, ok := e.(ECLogger); ok {
+		return logger.ECLog()
 	}
 	return ""
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Refactor: simplify `ECLog`**
> 
> - Replaces the explicit type switch in `ECLog` with an `ECLogger` interface assertion and delegation to `ECLog()` when implemented; otherwise returns empty string
> - Introduces/uses `ECLogger` interface (`ECLog() string`) for event-specific logging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91b940eb3269d80a7af9716817cea65368126867. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->