### PR TITLE
Fix sending Transmission content with template_id.

### DIFF
--- a/transmissions.go
+++ b/transmissions.go
@@ -126,16 +126,28 @@ func ParseRecipients(recips interface{}) (ra *[]Recipient, err error) {
 func ParseContent(content interface{}) (err error) {
 	switch rVal := content.(type) {
 	case map[string]interface{}:
-		_, isOk := rVal["template_id"]
-		if isOk {
+		var found bool
+		for key := range rVal {
+			if strings.ToLower(key) == "template_id" {
+				found = true
+				break
+			}
+		}
+		if found {
 			return nil
 		}
 		return fmt.Errorf("Transmission.Content objects must contain a key `template_id`")
 	case map[string]string:
 		// Have to duplicate logic here, we cannot add it above because it will then conflate rVal as an interface{}
 		// Exact error message: invalid operation: cannot index rVal (variable of type interface{})
-		_, isOk := rVal["template_id"]
-		if isOk {
+		var found bool
+		for key := range rVal {
+			if strings.ToLower(key) == "template_id" {
+				found = true
+				break
+			}
+		}
+		if found {
 			return nil
 		}
 		return fmt.Errorf("Transmission.Content objects must contain a key `template_id`")

--- a/transmissions.go
+++ b/transmissions.go
@@ -126,26 +126,19 @@ func ParseRecipients(recips interface{}) (ra *[]Recipient, err error) {
 func ParseContent(content interface{}) (err error) {
 	switch rVal := content.(type) {
 	case map[string]interface{}:
-		for k, v := range rVal {
-			switch vVal := v.(type) {
-			case string:
-				if strings.EqualFold(k, "template_id") {
-					return nil
-				}
-			default:
-				return fmt.Errorf("Transmission.Content objects must contain string values, not [%T]", vVal)
-			}
+		_, isOk := rVal["template_id"]
+		if isOk {
+			return nil
 		}
 		return fmt.Errorf("Transmission.Content objects must contain a key `template_id`")
-
 	case map[string]string:
-		for k := range rVal {
-			if strings.EqualFold(k, "template_id") {
-				return nil
-			}
+		// Have to duplicate logic here, we cannot add it above because it will then conflate rVal as an interface{}
+		// Exact error message: invalid operation: cannot index rVal (variable of type interface{})
+		_, isOk := rVal["template_id"]
+		if isOk {
+			return nil
 		}
 		return fmt.Errorf("Transmission.Content objects must contain a key `template_id`")
-
 	case Content:
 		te := &Template{Name: "tmp", Content: rVal}
 		return te.Validate()


### PR DESCRIPTION
Current logic is flawed in 2 ways.

1. Iterating over a Golang map is not deterministic
2. Other data types are actually valid to pass into message such as CC and BCC which are `map[string]string` types. Logic would early return when it found `template_id` based on [1], but because iterating keys over a map is not deterministic, it would fetch `CC` and then err out because it's `map[string]string` not `string`